### PR TITLE
Support nightly Julia builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can either specify specific Julia versions or version ranges. If you specify
 - `1.2.0` is a valid semver version. The action will try to download exactly this version. If it's not available, the build step will fail.
 - `1.0` is a version range that will match the highest available Julia version that starts with `1.0`, e.g. `1.0.5`.
 - `^1.3.0-rc1` is a caret version range that includes preleases. It matches all versions `≥ 1.3.0-rc1` and `< 1.4.0`.
+- `nightly` will install the latest nightly build.
 
 Internally the action uses node's semver package to resolve version ranges. Its [documentation](https://github.com/npm/node-semver#advanced-range-syntax) contains more details on the version range syntax.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ steps:
 In no particular order:
 
 * Check if a cached version of Julia is available instead of installing it everytime CI runs ([waiting on GitHub to add proper caching](https://twitter.com/natfriedman/status/1164210683979812869))
-* Add support for nightly Julia builds.
 * Add CI script that checks if tags have been updated on release.
 * Hash and signature checks.
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,5 +1,7 @@
 import * as installer from '../src/installer'
 
+import * as semver from 'semver'
+
 const testVersions = ['v1.3.0-rc4', 'v1.3.0-rc3', 'v1.3.0-rc2', 'v1.0.5', 'v1.2.0', 'v1.3.0-rc1', 'v1.2.0-rc3', 'v1.3.0-alpha', 'v1.2.0-rc2', 'v1.2.0-rc1', 'v1.1.1', 'v1.0.4', 'v1.1.0', 'v1.1.0-rc2', 'v1.1.0-rc1', 'v1.0.3', 'v1.0.2', 'v1.0.1', 'v1.0.0']
 
 describe('installer tests', () => {
@@ -25,6 +27,16 @@ describe('installer tests', () => {
                 expect(await installer.getJuliaVersion(testVersions, '1.0')).toEqual('1.0.5')
                 expect(await installer.getJuliaVersion(testVersions, '^1.3.0-rc1')).toEqual('1.3.0-rc4')
                 expect(await installer.getJuliaVersion(testVersions, '^1.2.0-rc1')).toEqual('1.2.0')
+            })
+        })
+    })
+    describe('node-semver behaviour', () => {
+        describe('Windows installer change', () => {
+            it('Correctly understands >1.4.0', () => {
+                expect(semver.gtr('1.4.0-rc1', '1.3', {includePrerelease: true})).toBeTruthy()
+                expect(semver.gtr('1.4.0-DEV', '1.3', {includePrerelease: true})).toBeTruthy()
+                expect(semver.gtr('1.3.1', '1.3', {includePrerelease: true})).toBeFalsy()
+                expect(semver.gtr('1.3.2-rc1', '1.3', {includePrerelease: true})).toBeFalsy()
             })
         })
     })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,6 +14,10 @@ describe('installer tests', () => {
                 expect(await installer.getJuliaVersion(['v1.2.0', 'v1.3.0-alpha', 'v1.3.0-rc1', 'v1.3.0'], '1.3.0-alpha')).toEqual('1.3.0-alpha')
                 expect(await installer.getJuliaVersion([], '1.3.0-rc2')).toEqual('1.3.0-rc2')
             })
+            it('Doesn\'t change the version when given `nightly`', async () => {
+                expect(await installer.getJuliaVersion([], 'nightly')).toEqual('nightly')
+                expect(await installer.getJuliaVersion(testVersions, 'nightly')).toEqual('nightly')
+            })
         })
         describe('version ranges', () => {
             it('Chooses the highest available version that matches the input', async () => {

--- a/bin/build-test-release
+++ b/bin/build-test-release
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+branch_name="$(git symbolic-ref --short -q HEAD)"
+
+git checkout -B test/"$branch_name"
+
+npm install
+npm run build
+npm test
+npm prune --production
+
+sed -i 's/node_modules/!node_modules/g' .gitignore
+git add node_modules
+git commit -a -m "Add production dependencies & build"

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -119,7 +119,13 @@ function installJulia(version, arch) {
                 return `${process.env.HOME}/julia`;
             case 'win32':
                 const juliaInstallationPath = path.join('C:', 'Julia');
-                yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`]);
+                if (version == 'nightly' || semver.gtr(version, '1.3', { includePrerelease: true })) {
+                    // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
+                    yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${juliaInstallationPath}" -NoNewWindow -Wait`]);
+                }
+                else {
+                    yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`]);
+                }
                 return juliaInstallationPath;
             case 'darwin':
                 yield exec.exec('hdiutil', ['attach', juliaDownloadPath]);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -123,7 +123,9 @@ function installJulia(version, arch) {
                 return juliaInstallationPath;
             case 'darwin':
                 yield exec.exec('hdiutil', ['attach', juliaDownloadPath]);
-                return `/Volumes/Julia-${version}/Julia-${getMajorMinorVersion(version)}.app/Contents/Resources/julia`;
+                yield exec.exec('mkdir', [`${process.env.HOME}/julia`]);
+                yield exec.exec('/bin/bash', ['-c', `cp -a /Volumes/Julia-*/Julia-*.app/Contents/Resources/julia ${process.env.HOME}`]);
+                return `${process.env.HOME}/julia`;
             default:
                 throw `Platform ${osPlat} is not supported`;
         }

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -113,8 +113,10 @@ function installJulia(version, arch) {
         // Install it
         switch (osPlat) {
             case 'linux':
-                const juliaExtractedFolder = yield tc.extractTar(juliaDownloadPath);
-                return path.join(juliaExtractedFolder, `julia-${version}`);
+                // tc.extractTar doesn't support stripping components, so we have to call tar manually
+                yield exec.exec('mkdir', [`${process.env.HOME}/julia`]);
+                yield exec.exec('tar', ['xf', juliaDownloadPath, '--strip-components=1', '-C', `${process.env.HOME}/julia`]);
+                return `${process.env.HOME}/julia`;
             case 'win32':
                 const juliaInstallationPath = path.join('C:', 'Julia');
                 yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`]);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -32,6 +32,10 @@ function getJuliaVersion(availableReleases, versionInput) {
             // versionInput is a valid version, use it directly
             return versionInput;
         }
+        // nightlies
+        if (versionInput == 'nightly') {
+            return 'nightly';
+        }
         // Use the highest available version that matches versionInput
         let version = semver.maxSatisfying(availableReleases, versionInput);
         if (version == null) {
@@ -47,9 +51,7 @@ function getMajorMinorVersion(version) {
     return version.split('.').slice(0, 2).join('.');
 }
 function getDownloadURL(version, arch) {
-    const baseURL = 'https://julialang-s3.julialang.org/bin';
     let platform;
-    const versionDir = getMajorMinorVersion(version);
     if (osPlat === 'win32') { // Windows
         platform = 'winnt';
     }
@@ -65,6 +67,14 @@ function getDownloadURL(version, arch) {
     else {
         throw `Platform ${osPlat} is not supported`;
     }
+    // nightlies
+    if (version == 'nightly') {
+        const baseURL = 'https://julialangnightlies-s3.julialang.org/bin';
+        return `${baseURL}/${platform}/${arch}/${getFileName('latest', arch)}`;
+    }
+    // normal versions
+    const baseURL = 'https://julialang-s3.julialang.org/bin';
+    const versionDir = getMajorMinorVersion(version);
     return `${baseURL}/${platform}/${arch}/${versionDir}/${getFileName(version, arch)}`;
 }
 function getFileName(version, arch) {
@@ -81,7 +91,12 @@ function getFileName(version, arch) {
         ext = 'dmg';
     }
     else if (osPlat === 'linux') { // Linux
-        versionExt = arch == 'x64' ? '-linux-x86_64' : '-linux-i686';
+        if (version == 'latest') { // nightly version
+            versionExt = arch == 'x64' ? '-linux64' : '-linux32';
+        }
+        else {
+            versionExt = arch == 'x64' ? '-linux-x86_64' : '-linux-i686';
+        }
         ext = 'tar.gz';
     }
     else {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,6 +21,11 @@ export async function getJuliaVersion(availableReleases: string[], versionInput:
         return versionInput
     }
 
+    // nightlies
+    if (versionInput == 'nightly') {
+        return 'nightly'
+    }
+
     // Use the highest available version that matches versionInput
     let version = semver.maxSatisfying(availableReleases, versionInput)
     if (version == null) {
@@ -38,9 +43,7 @@ function getMajorMinorVersion(version: string): string {
 }
 
 function getDownloadURL(version: string, arch: string): string {
-    const baseURL = 'https://julialang-s3.julialang.org/bin'
     let platform: string
-    const versionDir = getMajorMinorVersion(version)
 
     if (osPlat === 'win32') { // Windows
         platform = 'winnt'
@@ -54,6 +57,16 @@ function getDownloadURL(version: string, arch: string): string {
     } else {
         throw `Platform ${osPlat} is not supported`
     }
+
+    // nightlies
+    if (version == 'nightly') {
+        const baseURL = 'https://julialangnightlies-s3.julialang.org/bin'
+        return `${baseURL}/${platform}/${arch}/${getFileName('latest', arch)}`
+    }
+
+    // normal versions
+    const baseURL = 'https://julialang-s3.julialang.org/bin'
+    const versionDir = getMajorMinorVersion(version)
 
     return `${baseURL}/${platform}/${arch}/${versionDir}/${getFileName(version, arch)}`
 }
@@ -71,7 +84,11 @@ function getFileName(version: string, arch: string): string {
         versionExt = '-mac64'
         ext = 'dmg'
     } else if (osPlat === 'linux') { // Linux
-        versionExt = arch == 'x64' ? '-linux-x86_64' : '-linux-i686'
+        if (version == 'latest') { // nightly version
+            versionExt = arch == 'x64' ? '-linux64' : '-linux32'
+        } else {
+            versionExt = arch == 'x64' ? '-linux-x86_64' : '-linux-i686'
+        }
         ext = 'tar.gz'
     } else {
         throw `Platform ${osPlat} is not supported`

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -112,7 +112,12 @@ export async function installJulia(version: string, arch: string): Promise<strin
             return `${process.env.HOME}/julia`
         case 'win32':
             const juliaInstallationPath = path.join('C:', 'Julia')
-            await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`])
+            if (version == 'nightly' || semver.gtr(version, '1.3', {includePrerelease: true})) {
+                // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
+                await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${juliaInstallationPath}" -NoNewWindow -Wait`])
+            } else {
+                await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`])
+            }
             return juliaInstallationPath
         case 'darwin':
             await exec.exec('hdiutil', ['attach', juliaDownloadPath])

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -116,7 +116,9 @@ export async function installJulia(version: string, arch: string): Promise<strin
             return juliaInstallationPath
         case 'darwin':
             await exec.exec('hdiutil', ['attach', juliaDownloadPath])
-            return `/Volumes/Julia-${version}/Julia-${getMajorMinorVersion(version)}.app/Contents/Resources/julia`
+            await exec.exec('mkdir', [`${process.env.HOME}/julia`])
+            await exec.exec('/bin/bash', ['-c', `cp -a /Volumes/Julia-*/Julia-*.app/Contents/Resources/julia ${process.env.HOME}`])
+            return `${process.env.HOME}/julia`
         default:
             throw `Platform ${osPlat} is not supported`
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -106,8 +106,10 @@ export async function installJulia(version: string, arch: string): Promise<strin
     // Install it
     switch (osPlat) {
         case 'linux':
-            const juliaExtractedFolder = await tc.extractTar(juliaDownloadPath)
-            return path.join(juliaExtractedFolder, `julia-${version}`)
+            // tc.extractTar doesn't support stripping components, so we have to call tar manually
+            await exec.exec('mkdir', [`${process.env.HOME}/julia`])
+            await exec.exec('tar', ['xf', juliaDownloadPath, '--strip-components=1', '-C', `${process.env.HOME}/julia`])
+            return `${process.env.HOME}/julia`
         case 'win32':
             const juliaInstallationPath = path.join('C:', 'Julia')
             await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${juliaInstallationPath}" -NoNewWindow -Wait`])


### PR DESCRIPTION
With this PR it's possible to install nightly versions of Julia

I have not been able to figure out the workflow syntax equivalent to `allow_failures` on Travis, so I didn't add a proper example yet.

Example run: https://github.com/julia-actions/Example.jl/commit/4a5e78ea79ab25e5f69ccc4a257f07a44c9d447d/checks?check_suite_id=326520284

---

I wanted to add tests for `getDownloadURL` but I could not figure out how to mock the value of a global constant in jest. I'll tackle that another time.

---

This is the last feature that was still missing before the interface is stable/(mostly) complete. Once merged, I'll tag a `v1.0.0` release.

---

(fixes #5)