### PR TITLE
Change show-versioninfo to always print full info for nightlies

### DIFF
--- a/.github/workflows/example-builds-nightly.yml
+++ b/.github/workflows/example-builds-nightly.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         julia-version: [nightly, 1.6-nightly]
         julia-arch: [x64, x86]
+        versioninfo: ['true', 'false', 'never']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS
         exclude:
@@ -35,5 +36,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-          show-versioninfo: 'true'
+          show-versioninfo: ${{ matrix.versioninfo }}
       - run: julia --version
+      - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'

--- a/.github/workflows/example-builds-nightly.yml
+++ b/.github/workflows/example-builds-nightly.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         julia-version: [nightly, 1.6-nightly]
         julia-arch: [x64, x86]
-        versioninfo: ['true', 'false', 'never']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS
         exclude:
@@ -36,6 +35,5 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-          show-versioninfo: ${{ matrix.versioninfo }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         julia-version: ['1.0.5', '1', '^1.5.0-beta1']
         julia-arch: [x64, x86]
-        versioninfo: ['true', 'false', 'never']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS
         exclude:
@@ -35,6 +34,5 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-          show-versioninfo: ${{ matrix.versioninfo }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.0.5', '1', '^1.5.0-beta1']
         julia-arch: [x64, x86]
+        versioninfo: ['true', 'false', 'never']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS
         exclude:
@@ -34,5 +35,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-          show-versioninfo: 'true'
+          show-versioninfo: ${{ matrix.versioninfo }}
       - run: julia --version
+      - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'

--- a/README.md
+++ b/README.md
@@ -43,8 +43,18 @@ This action sets up a Julia environment for use in actions by downloading a spec
     # Default: x64
     arch: ''
 
-    # If true, display the output of InteractiveUtils.versioninfo() after installing.
-    # See "versioninfo" below for example usage.
+    # Set the display setting for printing InteractiveUtils.versioninfo() after installing.
+    #
+    # Starting Julia and running InteractiveUtils.versioninfo() takes a significant amount of time (1s or ~10% of the total build time in testing),
+    # so you may not want to run it in every build, in particular on paid runners, as this cost will add up quickly.
+    #
+    # See "versioninfo" below for example usage and further explanations.
+    #
+    # Supported values: true | false | never
+    #
+    # true: Always print versioninfo
+    # false: Only print versioninfo for nightly Julia
+    # never: Never print versioninfo
     #
     # Default: false
     show-versioninfo: ''
@@ -179,18 +189,13 @@ jobs:
 
 ### versioninfo
 
-By default, only a brief version identifier is printed in the run log. You can display the full `versioninfo` by adding `show-versioninfo`.
-Here's an example that prints this information just for `nightly`:
+By default, only the output of `julia --version` is printed as verification that Julia has been installed for stable versions of Julia.
+`InteractiveUtils.versioninfo()` is run by default for nightly builds.
 
-```yaml
-    - uses: julia-actions/setup-julia@v1
-      with:
-        version: ${{ matrix.version }}
-        arch: ${{ matrix.arch }}
-        show-versioninfo: ${{ matrix.version == 'nightly' }}
- ```
- 
-You use `'true'` if you want it printed for all Julia versions.
+Starting Julia and printing the full versioninfo takes a significant amount of time (1s or ~10% of the total build time in testing), so you may not want to run it in every build, in particular on paid runners as this cost will add up quickly.
+However, `julia --version` does not provide sufficient information to know which commit a nightly binary was built from, therefore it is useful to show the full versioninfo on nightly builds regardless.
+
+You can override this behaviour by changing the input to `never` if you never want to run `InteractiveUtils.versioninfo()` or to `true` if you always want to run `InteractiveUtils.versioninfo()`, even on stable Julia builds.
 
 ## Versioning
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -184,3 +184,33 @@ function installJulia(versionInfo, version, arch) {
     });
 }
 exports.installJulia = installJulia;
+/**
+ * Test if Julia has been installed and print the version.
+ *
+ * true => always show versioninfo
+ * false => only show on nightlies
+ * never => never show it anywhere
+ *
+ * @param showVersionInfoInput
+ */
+function showVersionInfo(showVersionInfoInput, version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
+        switch (showVersionInfoInput) {
+            case 'true':
+                return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
+            case 'false':
+                if (version.endsWith('nightly')) {
+                    return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
+                }
+                else {
+                    return exec.exec('julia', ['--version']);
+                }
+            case 'never':
+                return exec.exec('julia', ['--version']);
+            default:
+                throw new Error(`${showVersionInfoInput} is not a valid value for show-versioninfo. Supported values: true | false | never`);
+        }
+    });
+}
+exports.showVersionInfo = showVersionInfo;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -196,20 +196,27 @@ exports.installJulia = installJulia;
 function showVersionInfo(showVersionInfoInput, version) {
     return __awaiter(this, void 0, void 0, function* () {
         // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
+        let exitCode;
         switch (showVersionInfoInput) {
             case 'true':
-                return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
+                exitCode = yield exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
+                break;
             case 'false':
                 if (version.endsWith('nightly')) {
-                    return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
+                    exitCode = yield exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
                 }
                 else {
-                    return exec.exec('julia', ['--version']);
+                    exitCode = yield exec.exec('julia', ['--version']);
                 }
+                break;
             case 'never':
-                return exec.exec('julia', ['--version']);
+                exitCode = yield exec.exec('julia', ['--version']);
+                break;
             default:
                 throw new Error(`${showVersionInfoInput} is not a valid value for show-versioninfo. Supported values: true | false | never`);
+        }
+        if (exitCode !== 0) {
+            throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`);
         }
     });
 }

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -79,7 +79,10 @@ function run() {
             core.setOutput('julia-bindir', path.join(juliaPath, 'bin'));
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
-            yield installer.showVersionInfo(showVersionInfoInput, version);
+            const exitCode = yield installer.showVersionInfo(showVersionInfoInput, version);
+            if (exitCode !== 0) {
+                throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`);
+            }
         }
         catch (error) {
             core.setFailed(error.message);

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -16,7 +16,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
-const exec = __importStar(require("@actions/exec"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
 const https = __importStar(require("https"));
@@ -79,15 +78,8 @@ function run() {
             // Set output
             core.setOutput('julia-bindir', path.join(juliaPath, 'bin'));
             // Test if Julia has been installed and print the version
-            if (core.getInput('show-versioninfo') == 'true') {
-                // If enabled, show the full version info
-                // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
-                exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()']);
-            }
-            else {
-                // Otherwise only print julia --version to save time
-                exec.exec('julia', ['--version']);
-            }
+            const showVersionInfoInput = core.getInput('show-versioninfo');
+            yield installer.showVersionInfo(showVersionInfoInput, version);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -79,10 +79,7 @@ function run() {
             core.setOutput('julia-bindir', path.join(juliaPath, 'bin'));
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
-            const exitCode = yield installer.showVersionInfo(showVersionInfoInput, version);
-            if (exitCode !== 0) {
-                throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`);
-            }
+            yield installer.showVersionInfo(showVersionInfoInput, version);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-julia",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-julia",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "private": true,
   "description": "setup Julia action",
   "main": "lib/setup-julia.js",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -178,3 +178,33 @@ export async function installJulia(versionInfo, version: string, arch: string): 
             throw new Error(`Platform ${osPlat} is not supported`)
     }
 }
+
+/**
+ * Test if Julia has been installed and print the version.
+ * 
+ * true => always show versioninfo
+ * false => only show on nightlies
+ * never => never show it anywhere
+ * 
+ * @param showVersionInfoInput 
+ */
+export async function showVersionInfo(showVersionInfoInput: string, version: string): Promise<number> {
+    // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
+    switch (showVersionInfoInput) {
+        case 'true':
+            return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
+    
+        case 'false':
+            if (version.endsWith('nightly')) {
+                return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
+            } else {
+                return exec.exec('julia', ['--version'])
+            }
+        
+        case 'never':
+            return exec.exec('julia', ['--version'])
+
+        default:
+            throw new Error(`${showVersionInfoInput} is not a valid value for show-versioninfo. Supported values: true | false | never`)
+    }
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -188,23 +188,32 @@ export async function installJulia(versionInfo, version: string, arch: string): 
  * 
  * @param showVersionInfoInput 
  */
-export async function showVersionInfo(showVersionInfoInput: string, version: string): Promise<number> {
+export async function showVersionInfo(showVersionInfoInput: string, version: string): Promise<void> {
     // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
+    let exitCode: number
+
     switch (showVersionInfoInput) {
         case 'true':
-            return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
+            exitCode = await exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
+            break
     
         case 'false':
             if (version.endsWith('nightly')) {
-                return exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
+                exitCode = await exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
             } else {
-                return exec.exec('julia', ['--version'])
+                exitCode = await exec.exec('julia', ['--version'])
             }
+            break
         
         case 'never':
-            return exec.exec('julia', ['--version'])
+            exitCode = await exec.exec('julia', ['--version'])
+            break
 
         default:
             throw new Error(`${showVersionInfoInput} is not a valid value for show-versioninfo. Supported values: true | false | never`)
+    }
+
+    if (exitCode !== 0) {
+        throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`)
     }
 }

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -76,7 +76,10 @@ async function run() {
 
         // Test if Julia has been installed and print the version
         const showVersionInfoInput = core.getInput('show-versioninfo')
-        await installer.showVersionInfo(showVersionInfoInput, version)
+        const exitCode = await installer.showVersionInfo(showVersionInfoInput, version)
+        if (exitCode !== 0) {
+            throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`)
+        }
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -76,10 +76,7 @@ async function run() {
 
         // Test if Julia has been installed and print the version
         const showVersionInfoInput = core.getInput('show-versioninfo')
-        const exitCode = await installer.showVersionInfo(showVersionInfoInput, version)
-        if (exitCode !== 0) {
-            throw new Error(`Julia could not be installed properly. Exit code: ${exitCode}`)
-        }
+        await installer.showVersionInfo(showVersionInfoInput, version)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -75,14 +75,8 @@ async function run() {
         core.setOutput('julia-bindir', path.join(juliaPath, 'bin'))
 
         // Test if Julia has been installed and print the version
-        if (core.getInput('show-versioninfo') == 'true') {
-            // If enabled, show the full version info
-            // --compile=min -O0 reduces the time from ~1.8-1.9s to ~0.8-0.9s
-            exec.exec('julia', ['--compile=min', '-O0', '-e', 'using InteractiveUtils; versioninfo()'])
-        } else {
-            // Otherwise only print julia --version to save time
-            exec.exec('julia', ['--version'])
-        }
+        const showVersionInfoInput = core.getInput('show-versioninfo')
+        await installer.showVersionInfo(showVersionInfoInput, version)
     } catch (error) {
         core.setFailed(error.message)
     }


### PR DESCRIPTION
Still need to write tests so that we don't have to run absurd amounts of workflows to test this but the feature itself is ready for review.