### PR TITLE
Add support for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ This action sets up a Julia environment for use in actions by downloading a spec
 
     # The architecture of the Julia binaries.
     #
-    # Supported values: x64 | x86
+    # Please note that installing aarch64 binaries only makes sense on self-hosted aarch64 runners.
+    # We currently don't run test builds on that architecture, so we cannot guarantee that the input won't break randomly,
+    # although there is no reason why it would.
+    #
+    # Supported values: x64 | x86 | aarch64 (untested)
     #
     # Default: x64
     arch: ''

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -32,7 +32,8 @@ const osMap = {
 };
 const archMap = {
     'x86': 'i686',
-    'x64': 'x86_64'
+    'x64': 'x86_64',
+    'aarch64': 'aarch64'
 };
 // Store information about the environment
 const osPlat = os.platform(); // possible values: win32 (Windows), linux (Linux), darwin (macOS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "setup-julia",
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -18,7 +18,8 @@ const osMap = {
 }
 const archMap = {
     'x86': 'i686',
-    'x64': 'x86_64'
+    'x64': 'x86_64',
+    'aarch64': 'aarch64'
 }
 
 // Store information about the environment


### PR DESCRIPTION
Setting the `arch` input to `aarch64` will install `aarch64` binaries,
intended to be used on aarch64-based self-hosted runners.

Please note that we currently don't run test builds on that
architecture, so we cannot guarantee that the input won't break
randomly, although there is no reason why it would.

In a future update, we may choose a default architecture based on the
arch of the runner.

Thanks to @giordano for providing a self-hosted runner for testing.