### PR TITLE
Update default runtime to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ outputs:
   julia-bindir:
     description: 'Path to the directory containing the Julia executable. Equivalent to JULIA_BINDIR: https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_BINDIR'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'download'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-julia",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-julia",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "description": "setup Julia action",
   "main": "lib/setup-julia.js",


### PR DESCRIPTION
EOL was almost a month ago. Woops.

I don't care about people using an old version of GitHub Enterprise, so I'm not going to annoy every single user of this action with a breaking update like GH did with their core actions. If you're a user of GHE: consider this a breaking update.