### PR TITLE
In the `arch` input, allow `X64` and `X86` as synonyms for `x64` and `x86`, respectively

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -32,7 +32,9 @@ const osMap = {
 };
 const archMap = {
     'x86': 'i686',
+    'X86': 'i686',
     'x64': 'x86_64',
+    'X64': 'x86_64',
     'aarch64': 'aarch64',
     'ARM64': 'aarch64'
 };

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -18,7 +18,9 @@ const osMap = {
 }
 const archMap = {
     'x86': 'i686',
+    'X86': 'i686',
     'x64': 'x86_64',
+    'X64': 'x86_64',
     'aarch64': 'aarch64',
     'ARM64': 'aarch64'
 }


### PR DESCRIPTION
To allow for compatibility with the [`${{ runner.arch }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context) variable, which takes on the following values: `X86`, `X64`, `ARM`, or `ARM64`.