### PR TITLE
In the `arch` input, allow `ARM64` as a synonym for `aarch64`

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -33,7 +33,8 @@ const osMap = {
 const archMap = {
     'x86': 'i686',
     'x64': 'x86_64',
-    'aarch64': 'aarch64'
+    'aarch64': 'aarch64',
+    'ARM64': 'aarch64'
 };
 // Store information about the environment
 const osPlat = os.platform(); // possible values: win32 (Windows), linux (Linux), darwin (macOS)

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,7 +19,8 @@ const osMap = {
 const archMap = {
     'x86': 'i686',
     'x64': 'x86_64',
-    'aarch64': 'aarch64'
+    'aarch64': 'aarch64',
+    'ARM64': 'aarch64'
 }
 
 // Store information about the environment


### PR DESCRIPTION
To allow for compatibility with the [`${{ runner.arch }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context) variable, which takes on the following values: `X86`, `X64`, `ARM`, or `ARM64`.

Fixes #107