### PR TITLE
On macOS, first try to find a tarball (`.tar.gz`) file, but fall back to `.dmg` if we can't find a tarball

### DIFF
--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0.5', '1', '^1.5.0-beta1']
+        julia-version: ['1.0.5', '1.2', '^1.5.0-beta1', '1']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -102,30 +102,57 @@ function getJuliaVersion(availableReleases, versionInput) {
     return version;
 }
 exports.getJuliaVersion = getJuliaVersion;
+function getDesiredFileExts() {
+    let fileExt1;
+    let hasFileExt2;
+    let fileExt2;
+    if (osPlat == 'win32') {
+        fileExt1 = 'exe';
+        hasFileExt2 = false;
+        fileExt2 = '';
+    }
+    else if (osPlat == 'darwin') {
+        fileExt1 = 'tar.gz';
+        hasFileExt2 = true;
+        fileExt2 = 'dmg';
+    }
+    else if (osPlat === 'linux') {
+        fileExt1 = 'tar.gz';
+        hasFileExt2 = false;
+        fileExt2 = '';
+    }
+    else {
+        throw new Error(`Platform ${osPlat} is not supported`);
+    }
+    return [fileExt1, hasFileExt2, fileExt2];
+}
 function getNightlyFileName(arch) {
-    let versionExt, ext;
+    let versionExt;
+    let fileExt1;
+    [fileExt1, ,] = getDesiredFileExts();
     if (osPlat == 'win32') {
         versionExt = arch == 'x64' ? '-win64' : '-win32';
-        ext = 'exe';
     }
     else if (osPlat == 'darwin') {
         if (arch == 'x86') {
             throw new Error('32-bit Julia is not available on macOS');
         }
         versionExt = '-mac64';
-        ext = 'dmg';
     }
     else if (osPlat === 'linux') {
         versionExt = arch == 'x64' ? '-linux64' : '-linux32';
-        ext = 'tar.gz';
     }
     else {
         throw new Error(`Platform ${osPlat} is not supported`);
     }
-    return `julia-latest${versionExt}.${ext}`;
+    return `julia-latest${versionExt}.${fileExt1}`;
 }
 function getFileInfo(versionInfo, version, arch) {
     const err = `Could not find ${archMap[arch]}/${version} binaries`;
+    let fileExt1;
+    let hasFileExt2;
+    let fileExt2;
+    [fileExt1, hasFileExt2, fileExt2] = getDesiredFileExts();
     if (version.endsWith('nightly')) {
         return null;
     }
@@ -134,7 +161,19 @@ function getFileInfo(versionInfo, version, arch) {
     }
     for (let file of versionInfo[version].files) {
         if (file.os == osMap[osPlat] && file.arch == archMap[arch]) {
-            return file;
+            if (file.extension == fileExt1) {
+                return file;
+            }
+        }
+    }
+    if (hasFileExt2) {
+        core.debug(`Could not find ${fileExt1}; trying to find ${fileExt2} instead`);
+        for (let file of versionInfo[version].files) {
+            if (file.os == osMap[osPlat] && file.arch == archMap[arch]) {
+                if (file.extension == fileExt2) {
+                    return file;
+                }
+            }
         }
     }
     throw err;
@@ -201,9 +240,17 @@ function installJulia(versionInfo, version, arch) {
                 }
                 return tempInstallDir;
             case 'darwin':
-                yield exec.exec('hdiutil', ['attach', juliaDownloadPath]);
-                yield exec.exec('/bin/bash', ['-c', `cp -a /Volumes/Julia-*/Julia-*.app/Contents/Resources/julia ${tempInstallDir}`]);
-                return path.join(tempInstallDir, 'julia');
+                if (fileInfo !== null && fileInfo.extension == 'dmg') {
+                    core.debug(`Support for .dmg files is deprecated and may be removed in a future release`);
+                    yield exec.exec('hdiutil', ['attach', juliaDownloadPath]);
+                    yield exec.exec('/bin/bash', ['-c', `cp -a /Volumes/Julia-*/Julia-*.app/Contents/Resources/julia ${tempInstallDir}`]);
+                    return path.join(tempInstallDir, 'julia');
+                }
+                else {
+                    // tc.extractTar doesn't support stripping components, so we have to call tar manually
+                    yield exec.exec('tar', ['xf', juliaDownloadPath, '--strip-components=1', '-C', tempInstallDir]);
+                    return tempInstallDir;
+                }
             default:
                 throw new Error(`Platform ${osPlat} is not supported`);
         }


### PR DESCRIPTION
As seen in https://github.com/JuliaLang/VersionsJSONUtil.jl/pull/4#issuecomment-1198801820, we currently don't have macOS tarballs for 1.1, 1.2, 1.3.

So, in this PR, we first try to use the tarball, but we fall back to the `.dmg` if we can't find the tarball.

---

Depends on: https://github.com/JuliaLang/VersionsJSONUtil.jl/pull/4

See also: #105, https://github.com/JuliaLang/VersionsJSONUtil.jl/issues/3