### PR TITLE
Remove mention of auto-updating versions file

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you want to run tests against the latest tagged version, no matter what versi
 
 #### Recently released versions
 
-The available Julia versions are pulled from [`versions.json`](https://julialang-s3.julialang.org/bin/versions.json). This file is automatically updated once a day. Therefore it may take up to 24 hours until a newly released Julia version is available in the action.
+The available Julia versions are pulled from [`versions.json`](https://julialang-s3.julialang.org/bin/versions.json).
 
 ### Matrix Testing
 


### PR DESCRIPTION
The workflow to build it is triggered manually as part of the release process now, so this should no longer be an issue and hasn't been one for quite a while.