### PR TITLE
Include `arm64` alias for `aarch64`

### DIFF
--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -14,7 +14,8 @@ const archSynonyms = {
     'x64': 'x64',
     'X64': 'x64',
     'aarch64': 'aarch64',
-    'ARM64': 'aarch64'
+    'ARM64': 'aarch64',
+    'arm64': 'aarch64'
 }
 
 async function run() {


### PR DESCRIPTION
When I use `act` to try some workflows, it fails to recognise the architecture in my Apple M1.

```
[Register Package/register]   ⭐ Run Main julia-actions/setup-julia@v1
[Register Package/register]   🐳  docker cp src=/Users/mofeing/.cache/act/julia-actions-setup-julia@v1/ dst=/var/run/act/actions/julia-actions-setup-julia@v1/
[Register Package/register]   🐳  docker exec cmd=[node /var/run/act/actions/julia-actions-setup-julia@v1/dist/index.js] user= workdir=
[Register Package/register]   💬  ::debug::platform: linux
[Register Package/register]   💬  ::debug::Downloading https://julialang-s3.julialang.org/bin/versions.json
[Register Package/register]   💬  ::debug::Downloading /tmp/d5ad4feb-e028-42b0-8167-086568e429c6
[Register Package/register]   💬  ::debug::download complete
[Register Package/register]   💬  ::debug::selected Julia version: undefined/1.6.7
[Register Package/register]   💬  ::debug::isExplicit: 1.6.7
[Register Package/register]   💬  ::debug::explicit? true
[Register Package/register]   💬  ::debug::checking cache: /opt/hostedtoolcache/julia/1.6.7/arm64
[Register Package/register]   💬  ::debug::not found
[Register Package/register]   💬  ::debug::could not find Julia undefined/1.6.7 in cache
[Register Package/register]   ❗  ::error::
[Register Package/register]   ❌  Failure - Main julia-actions/setup-julia@v1
[Register Package/register]   ⚙  ::set-output:: julia-version=1.6.7
[Register Package/register] exitcode '1': failure
[Register Package/register] 🏁  Job failed
```

Problem is that `${{ runner.arch }}` in Apple M-series is defined as `arm64` but only `ARM64` and `aarch64` are defined.

This PR should fix arch lookup in Apple M-series.