### PR TITLE
set retry limit

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -86,7 +86,7 @@ function getJuliaVersionInfo() {
         }), {
             retries: 5,
             onRetry: (err) => {
-                core.debug(`Download of versions.json failed, trying again. Error: ${err}`);
+                core.info(`Download of versions.json failed, trying again. Error: ${err}`);
             }
         });
         return JSON.parse(fs.readFileSync(versionsFile).toString());
@@ -229,7 +229,7 @@ function installJulia(versionInfo, version, arch) {
         }), {
             retries: 5,
             onRetry: (err) => {
-                core.debug(`Download of ${downloadURL} failed, trying again. Error: ${err}`);
+                core.info(`Download of ${downloadURL} failed, trying again. Error: ${err}`);
             }
         });
         // Verify checksum

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -84,6 +84,7 @@ function getJuliaVersionInfo() {
         const versionsFile = yield retry((bail) => __awaiter(this, void 0, void 0, function* () {
             return yield tc.downloadTool('https://julialang-s3.julialang.org/bin/versions.json');
         }), {
+            retries: 5,
             onRetry: (err) => {
                 core.debug(`Download of versions.json failed, trying again. Error: ${err}`);
             }
@@ -226,6 +227,7 @@ function installJulia(versionInfo, version, arch) {
         const juliaDownloadPath = yield retry((bail) => __awaiter(this, void 0, void 0, function* () {
             return yield tc.downloadTool(downloadURL);
         }), {
+            retries: 5,
             onRetry: (err) => {
                 core.debug(`Download of ${downloadURL} failed, trying again. Error: ${err}`);
             }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -54,6 +54,7 @@ export async function getJuliaVersionInfo(): Promise<object> {
     const versionsFile = await retry(async (bail: Function) => {
         return await tc.downloadTool('https://julialang-s3.julialang.org/bin/versions.json')
     }, {
+        retries: 5,
         onRetry: (err: Error) => {
             core.debug(`Download of versions.json failed, trying again. Error: ${err}`)
         }
@@ -208,6 +209,7 @@ export async function installJulia(versionInfo, version: string, arch: string): 
     const juliaDownloadPath = await retry(async (bail: Function) => {
         return await tc.downloadTool(downloadURL)
     }, {
+        retries: 5,
         onRetry: (err: Error) => {
             core.debug(`Download of ${downloadURL} failed, trying again. Error: ${err}`)
         }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -56,7 +56,7 @@ export async function getJuliaVersionInfo(): Promise<object> {
     }, {
         retries: 5,
         onRetry: (err: Error) => {
-            core.debug(`Download of versions.json failed, trying again. Error: ${err}`)
+            core.info(`Download of versions.json failed, trying again. Error: ${err}`)
         }
     })
 
@@ -211,7 +211,7 @@ export async function installJulia(versionInfo, version: string, arch: string): 
     }, {
         retries: 5,
         onRetry: (err: Error) => {
-            core.debug(`Download of ${downloadURL} failed, trying again. Error: ${err}`)
+            core.info(`Download of ${downloadURL} failed, trying again. Error: ${err}`)
         }
     })
 


### PR DESCRIPTION
If you give the version `1.9-nightly` this action hangs indefinitely.

```
##[debug]Downloading https://julialangnightlies-s3.julialang.org/bin/linux/x64/1.9/julia-latest-linux64.tar.gz
##[debug]Destination /home/pointcheck/actions-runner/_work/_temp/364c19a7-e87b-4032-96dd-6392988b11de
##[debug]Failed to download from "https://julialangnightlies-s3.julialang.org/bin/linux/x64/1.9/julia-latest-linux64.tar.gz". Code(404) Message(Not Found)
##[debug]Download of https://julialangnightlies-s3.julialang.org/bin/linux/x64/1.9/julia-latest-linux64.tar.gz failed, trying again. Error: Error: Unexpected HTTP response: 404
...
```