### PR TITLE
Use .tar.gz files where available for faster win install

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -125,9 +125,9 @@ function getDesiredFileExts() {
     let hasFileExt2;
     let fileExt2;
     if (osPlat == 'win32') {
-        fileExt1 = 'exe';
-        hasFileExt2 = false;
-        fileExt2 = '';
+        fileExt1 = 'tar.gz';
+        hasFileExt2 = true;
+        fileExt2 = 'exe';
     }
     else if (osPlat == 'darwin') {
         fileExt1 = 'tar.gz';
@@ -249,12 +249,18 @@ function installJulia(versionInfo, version, arch) {
                 yield exec.exec('tar', ['xf', juliaDownloadPath, '--strip-components=1', '-C', tempInstallDir]);
                 return tempInstallDir;
             case 'win32':
-                if (version.endsWith('nightly') || semver.gtr(version, '1.3', { includePrerelease: true })) {
-                    // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
-                    yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`]);
+                if (fileInfo !== null && fileInfo.extension == 'exe') {
+                    if (version.endsWith('nightly') || semver.gtr(version, '1.3', { includePrerelease: true })) {
+                        // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
+                        yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`]);
+                    }
+                    else {
+                        yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`]);
+                    }
                 }
                 else {
-                    yield exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`]);
+                    // This is the more common path. Using .tar.gz is much faster
+                    yield exec.exec('powershell', ['-Command', `tar xf ${juliaDownloadPath} --strip-components=1 -C ${tempInstallDir}`]);
                 }
                 return tempInstallDir;
             case 'darwin':

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -99,9 +99,9 @@ function getDesiredFileExts(): [string, boolean, string] {
     let fileExt2: string
 
     if (osPlat == 'win32') {
-        fileExt1 = 'exe'
-        hasFileExt2 = false
-        fileExt2 = ''
+        fileExt1 = 'tar.gz'
+        hasFileExt2 = true
+        fileExt2 = 'exe'
     } else if (osPlat == 'darwin') {
         fileExt1 = 'tar.gz'
         hasFileExt2 = true
@@ -233,11 +233,16 @@ export async function installJulia(versionInfo, version: string, arch: string): 
             await exec.exec('tar', ['xf', juliaDownloadPath, '--strip-components=1', '-C', tempInstallDir])
             return tempInstallDir
         case 'win32':
-            if (version.endsWith('nightly') || semver.gtr(version, '1.3', {includePrerelease: true})) {
-                // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
-                await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`])
+            if (fileInfo !== null && fileInfo.extension == 'exe') {
+                if (version.endsWith('nightly') || semver.gtr(version, '1.3', {includePrerelease: true})) {
+                    // The installer changed in 1.4: https://github.com/JuliaLang/julia/blob/ef0c9108b12f3ae177c51037934351ffa703b0b5/NEWS.md#build-system-changes
+                    await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/SILENT /dir=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`])
+                } else {
+                    await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`])
+                }
             } else {
-                await exec.exec('powershell', ['-Command', `Start-Process -FilePath ${juliaDownloadPath} -ArgumentList "/S /D=${path.join(process.cwd(), tempInstallDir)}" -NoNewWindow -Wait`])
+                // This is the more common path. Using .tar.gz is much faster
+                await exec.exec('powershell', ['-Command', `tar xf ${juliaDownloadPath} --strip-components=1 -C ${tempInstallDir}`])
             }
             return tempInstallDir
         case 'darwin':


### PR DESCRIPTION
It currently takes almost a minute to install julia on windows via the .exe installer.
.zip takes ~42 seconds
.tar.gz takes ~12s :tada:

So let's use `.tar.gz` which is available all the way back to julia v1, and the exe if not

Closes https://github.com/julia-actions/setup-julia/issues/64