### PR TITLE
add test for julia install and mtime maintenance

### DIFF
--- a/.github/scripts/common-tests.jl
+++ b/.github/scripts/common-tests.jl
@@ -1,0 +1,11 @@
+if !occursin("hostedtoolcache", Sys.BINDIR)
+    error("the wrong julia is being used: $(Sys.BINDIR)")
+end
+if VERSION >= v"1.7.0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
+    using Pkg
+    src = pkgdir(Pkg, "src", "Pkg.jl")
+    # mtime is when it's compressed, ctime is when the file is extracted
+    if mtime(src) >= ctime(src)
+        error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
+    end
+end

--- a/.github/workflows/example-builds-defaultarch.yml
+++ b/.github/workflows/example-builds-defaultarch.yml
@@ -45,16 +45,4 @@ jobs:
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
       - name: "Check that the correct julia is used and that archive mtimes are maintained"
-        run: |
-          if !occursin("hostedtoolcache", Sys.BINDIR)
-            error("the wrong julia is being used: $Sys.BINDIR")
-          end
-          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
-            using Pkg
-            src = pkgdir(Pkg, "src", "Pkg.jl")
-            # mtime is when it's compacted, ctime is when the file is extracted
-            if !<(mtime(src), ctime(src))
-              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
-            end
-          end
-        shell: julia --startup-file=no --color=yes {0}
+        run: julia --startup-file=no --color=yes ./.github/scripts/common-tests.jl

--- a/.github/workflows/example-builds-defaultarch.yml
+++ b/.github/workflows/example-builds-defaultarch.yml
@@ -44,3 +44,17 @@ jobs:
           version: ${{ matrix.julia-version }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
+      - name: "Check that the correct julia is used and that archive mtimes are maintained"
+        run: |
+          if !occursin("hostedtoolcache", Sys.BINDIR)
+            error("the wrong julia is being used: $Sys.BINDIR")
+          end
+          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
+            using Pkg
+            src = pkgdir(Pkg, "src", "Pkg.jl")
+            # mtime is when it's compacted, ctime is when the file is extracted
+            if !<(mtime(src), ctime(src))
+              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
+            end
+          end
+        shell: julia --startup-file=no --color=yes {0}

--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -43,16 +43,4 @@ jobs:
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
       - name: "Check that the correct julia is used and that archive mtimes are maintained"
-        run: |
-          if !occursin("hostedtoolcache", Sys.BINDIR)
-            error("the wrong julia is being used: $Sys.BINDIR")
-          end
-          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
-            using Pkg
-            src = pkgdir(Pkg, "src", "Pkg.jl")
-            # mtime is when it's compacted, ctime is when the file is extracted
-            if !<(mtime(src), ctime(src))
-              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
-            end
-          end
-        shell: julia --startup-file=no --color=yes {0}
+        run: julia --startup-file=no --color=yes ./.github/scripts/common-tests.jl

--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -42,3 +42,17 @@ jobs:
           version: ${{ matrix.julia-version }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
+      - name: "Check that the correct julia is used and that archive mtimes are maintained"
+        run: |
+          if !occursin("hostedtoolcache", Sys.BINDIR)
+            error("the wrong julia is being used: $Sys.BINDIR")
+          end
+          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
+            using Pkg
+            src = pkgdir(Pkg, "src", "Pkg.jl")
+            # mtime is when it's compacted, ctime is when the file is extracted
+            if !<(mtime(src), ctime(src))
+              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
+            end
+          end
+        shell: julia --startup-file=no --color=yes {0}

--- a/.github/workflows/example-builds-nightly.yml
+++ b/.github/workflows/example-builds-nightly.yml
@@ -50,3 +50,19 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
+      - name: "Check that the correct julia is used"
+        run: julia -e 'occursin("hostedtoolcache", Sys.BINDIR) || error()'
+      - name: "Check that the correct julia is used and that archive mtimes are maintained"
+        run: |
+          if !occursin("hostedtoolcache", Sys.BINDIR)
+            error("the wrong julia is being used: $Sys.BINDIR")
+          end
+          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
+            using Pkg
+            src = pkgdir(Pkg, "src", "Pkg.jl")
+            # mtime is when it's compacted, ctime is when the file is extracted
+            if !<(mtime(src), ctime(src))
+              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
+            end
+          end
+        shell: julia --startup-file=no --color=yes {0}

--- a/.github/workflows/example-builds-nightly.yml
+++ b/.github/workflows/example-builds-nightly.yml
@@ -50,19 +50,5 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
-      - name: "Check that the correct julia is used"
-        run: julia -e 'occursin("hostedtoolcache", Sys.BINDIR) || error()'
       - name: "Check that the correct julia is used and that archive mtimes are maintained"
-        run: |
-          if !occursin("hostedtoolcache", Sys.BINDIR)
-            error("the wrong julia is being used: $Sys.BINDIR")
-          end
-          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
-            using Pkg
-            src = pkgdir(Pkg, "src", "Pkg.jl")
-            # mtime is when it's compacted, ctime is when the file is extracted
-            if !<(mtime(src), ctime(src))
-              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
-            end
-          end
-        shell: julia --startup-file=no --color=yes {0}
+        run: julia --startup-file=no --color=yes ./.github/scripts/common-tests.jl

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -51,16 +51,4 @@ jobs:
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
       - name: "Check that the correct julia is used and that archive mtimes are maintained"
-        run: |
-          if !occursin("hostedtoolcache", Sys.BINDIR)
-            error("the wrong julia is being used: $Sys.BINDIR")
-          end
-          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
-            using Pkg
-            src = pkgdir(Pkg, "src", "Pkg.jl")
-            # mtime is when it's compacted, ctime is when the file is extracted
-            if !<(mtime(src), ctime(src))
-              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
-            end
-          end
-        shell: julia --startup-file=no --color=yes {0}
+        run: julia --startup-file=no --color=yes ./.github/scripts/common-tests.jl

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -50,3 +50,17 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - run: julia --version
       - run: julia --compile=min -O0 -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
+      - name: "Check that the correct julia is used and that archive mtimes are maintained"
+        run: |
+          if !occursin("hostedtoolcache", Sys.BINDIR)
+            error("the wrong julia is being used: $Sys.BINDIR")
+          end
+          if VERSION > v"1.7.0-0" # pkgdir was introduced here, and before then mtime wasn't a problem so just skip
+            using Pkg
+            src = pkgdir(Pkg, "src", "Pkg.jl")
+            # mtime is when it's compacted, ctime is when the file is extracted
+            if !<(mtime(src), ctime(src))
+              error("source mtime ($(mtime(src))) is not earlier than ctime ($(ctime(src)))")
+            end
+          end
+        shell: julia --startup-file=no --color=yes {0}


### PR DESCRIPTION
This should fail on master, and will be added to #196 which should pass

The mtime test only runs on 1.7+ because that's when `pkgdir` is available, and the mtime issue isn't really a problem back then. It's more since stdlibs have started to be removed from the sysimage.

Interestingly on windows the archive mtimes are maintained, which explains why the cache action works well already on windows https://github.com/julia-actions/cache/issues/85#issue-2064424120 