### PR TITLE
update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ outputs:
   julia-bindir:
     description: 'Path to the directory containing the Julia executable. Equivalent to JULIA_BINDIR: https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_BINDIR'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'download'


### PR DESCRIPTION
Fixes #208 

Node 16 is deprecated, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/