### PR TITLE
Fix the Apple Silicon (macOS `aarch64` / `arm64`) URLs for Julia nightly

### DIFF
--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: [nightly, 1.10-nightly]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest, macOS-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -19,7 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: [nightly, 1.10-nightly]
-        os: [ubuntu-latest, macOS-latest, windows-latest, macOS-14]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-11 # Intel
+          - macos-12 # Intel
+          - macos-13 # Intel
+          - macos-14 # Apple Silicon
+          - macos-latest # Currently Intel, but will probably point to Apple Silicon in the future
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -156,10 +156,23 @@ function getNightlyFileName(arch) {
         if (arch == 'x86') {
             throw new Error('32-bit Julia is not available on macOS');
         }
-        versionExt = '-mac64';
+        else if (arch == 'aarch64') {
+            versionExt = '-macaarch64';
+        }
+        else {
+            versionExt = '-mac64';
+        }
     }
     else if (osPlat === 'linux') {
-        versionExt = arch == 'x64' ? '-linux64' : '-linux32';
+        if (arch == 'x86') {
+            versionExt = '-linux32';
+        }
+        else if (arch == 'aarch64') {
+            versionExt = '-linux-aarch64';
+        }
+        else {
+            versionExt = '-linux64';
+        }
     }
     else {
         throw new Error(`Platform ${osPlat} is not supported`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -128,10 +128,19 @@ function getNightlyFileName(arch: string): string {
     } else if (osPlat == 'darwin') {
         if (arch == 'x86') {
             throw new Error('32-bit Julia is not available on macOS')
+        } else if (arch == 'aarch64') {
+            versionExt = '-macaarch64'
+        } else {
+            versionExt = '-mac64'
         }
-        versionExt = '-mac64'
     } else if (osPlat === 'linux') {
-        versionExt = arch == 'x64' ? '-linux64' : '-linux32'
+        if (arch == 'x86') {
+            versionExt = '-linux32'
+        } else if (arch == 'aarch64') {
+            versionExt = '-linux-aarch64'
+        } else {
+            versionExt = '-linux64'
+        }
     } else {
         throw new Error(`Platform ${osPlat} is not supported`)
     }


### PR DESCRIPTION
Testing with julia nightly on `macos-14` (aarch64) currently fails with:
```
Run julia-actions/setup-julia@v1
Download of https://julialangnightlies-s3.julialang.org/bin/mac/aarch64/julia-latest-mac64.tar.gz failed, trying again. Error: Error: Unexpected HTTP response: 404
```
The filename is slightly wrong and should have `macaarch64` instead of `mac64`, this PR tries to fix this for linux and macOS.
I also added `macOS-14` (for the [new M1 runners](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)) to the nightly tests.

Note that these URLs are a bit of a guesswork. On the official nightly downloads page they have a different format using a slightly more homogeneous pattern (at least for linux and macos):
- `x86_64`, `i686` and `aarch64` in the baseurl instead of `x64` and `x86`.
- `macos` instead of `mac` in the baseurl.
- filename `julia-latest-<osname>-<arch>`
Adjusting to this pattern could simplify the code a bit even though it would still need a bunch of extra cases for windows.
But I don't really know anything about the stability of all those URLs.

_Edit:_ Looks like the new tests on the M1 were successful: https://github.com/julia-actions/setup-julia/actions/runs/7855176535/job/21436628690?pr=220#step:5:15