### PR TITLE
Default to the Windows system tar, but add an escape hatch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Setup Julia environment'
 description: 'Setup a Julia environment and add it to the PATH'
 author: 'Sascha Mann'
-inputs: 
+inputs:
   version:
     description: 'The Julia version to download (if necessary) and use. Example: 1.0.4'
     default: '1'
@@ -17,6 +17,10 @@ inputs:
     description: 'Display InteractiveUtils.versioninfo() after installing'
     required: false
     default: 'false'
+  tar:
+    description: '[private internal]. Custom tar command to use. This is not part of the public API of this action.'
+    required: false
+    default: ''
 outputs:
   julia-version:
     description: 'The installed Julia version. May vary from the version input if a version range was given as input.'

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -291,7 +291,22 @@ function installJulia(dest, versionInfo, version, arch) {
                 }
                 else {
                     // This is the more common path. Using .tar.gz is much faster
-                    yield exec.exec('powershell', ['-Command', `tar xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`]);
+                    const tarInput = core.getInput('tar').trim();
+                    if (tarInput) {
+                        // If the user provides the `tar` input, use that.
+                        const tar_command = `& "${tarInput}" xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`;
+                        core.debug(`tar_command: ${tar_command}`);
+                        yield exec.exec('powershell', ['-Command', tar_command]);
+                    }
+                    else {
+                        // Otherwise, on Windows, use the Windows system tar (not the Git Bash tar).
+                        // https://github.com/julia-actions/setup-julia/issues/205
+                        //
+                        // // don't use the Git bash provided tar. Issue #205
+                        const tar_command = `& "$env:WINDIR/System32/tar" xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`;
+                        core.debug(`tar_command: ${tar_command}`);
+                        yield exec.exec('powershell', ['-Command', tar_command]);
+                    }
                 }
                 return dest;
             case 'darwin':

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -263,7 +263,21 @@ export async function installJulia(dest: string, versionInfo, version: string, a
                 }
             } else {
                 // This is the more common path. Using .tar.gz is much faster
-                await exec.exec('powershell', ['-Command', `tar xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`])
+                const tarInput = core.getInput('tar').trim()
+                if (tarInput) {
+                    // If the user provides the `tar` input, use that.
+                    const tar_command = `& "${tarInput}" xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`
+                    core.debug(`tar_command: ${tar_command}`)
+                    await exec.exec('powershell', ['-Command', tar_command])
+                } else {
+                    // Otherwise, on Windows, use the Windows system tar (not the Git Bash tar).
+                    // https://github.com/julia-actions/setup-julia/issues/205
+                    //
+                    // // don't use the Git bash provided tar. Issue #205
+                    const tar_command = `& "$env:WINDIR/System32/tar" xf ${juliaDownloadPath} --strip-components=1 -C ${dest}`
+                    core.debug(`tar_command: ${tar_command}`)
+                    await exec.exec('powershell', ['-Command', tar_command])
+                }
             }
             return dest
         case 'darwin':


### PR DESCRIPTION
Fixes #205
Replaces #206 (closes #206)

This is almost identical to #206, except this PR adds a (non-public internal) `tar` input as an "escape hatch", so that if necessary the user can provide the correct `tar` to be used.

For example, the user could manually manipulate their PATH before they run this action, and then they could just do this:

```yaml
- uses: julia-actions/setup-julia@v2
  with:
    version: '1'
    tar: 'tar'
```

And then this will just pick up the `tar` that the user put first in their PATH.