### PR TITLE
CI: stop testing on macOS 11

### DIFF
--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-11 # Intel
+          # - macos-11 # Intel
           - macos-12 # Intel
           - macos-13 # Intel
           - macos-14 # Apple Silicon


### PR DESCRIPTION
>  This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.