### PR TITLE
Improve the error logging for the case of Julia 1.6 or 1.7 on Apple Silicon (`macos-latest` or `macos-14`)

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -253,18 +253,8 @@ function getFileInfo(versionInfo, version, arch) {
                     `available for Apple Silicon macOS.\n` +
                     `Therefore, it is not possible to install Julia with the current ` +
                     `constraints.\n` +
-                    `You have three options:\n` +
-                    `Option 1: Switch from "macos-latest" to "macos-13" (because ` +
-                    `"macos-13" runs on Intel (x86_64) macOS machines.)\n` +
-                    `Option 2: Modify your CI matrix to exclude Julia 1.6 and 1.7 ` +
-                    `on "macos-latest", but continue to run Julia 1.6 or 1.7 on ` +
-                    `"macos-13".\n` +
-                    `Option 2: Explicitly request an x86_64 build of Julia, which ` +
-                    `macOS will run under emulation with Rosetta 2. To choose this ` +
-                    `option, explicitly pass "x64" as the value of the "arch" input ` +
-                    `to this action.\n` +
-                    `For more information, see this Discourse post: ` +
-                    `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019\n`;
+                    `For instructions on how to fix this error, please see the following Discourse post: ` +
+                    `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019`;
                 core.error(msg);
             }
         }

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -214,6 +214,7 @@ function getFileInfo(versionInfo, version, arch) {
         return null;
     }
     if (!versionInfo[version]) {
+        core.error(`Encountered error: ${err}`);
         throw err;
     }
     for (let file of versionInfo[version].files) {
@@ -232,7 +233,43 @@ function getFileInfo(versionInfo, version, arch) {
                 }
             }
         }
+        // The following block is just to provide improved log messages in the CI logs.
+        // We specifically want to improve the case where someone is trying to install
+        // Julia 1.6 or 1.7 on Apple Silicon (aarch64) macOS.
+        {
+            const one_fileext_is_targz = (fileExt1 == "tar.gz") || (fileExt2 == "tar.gz");
+            const one_fileext_is_dmg = (fileExt1 == "dmg") || (fileExt2 == "dmg");
+            const one_fileext_is_targz_and_other_is_dmg = one_fileext_is_targz && one_fileext_is_dmg;
+            // We say that "this Julia version does NOT have native binaries for Apple Silicon"
+            // if and only if "this Julia version is < 1.8.0"
+            const this_julia_version_does_NOT_have_native_binaries_for_apple_silicon = semver.lt(version, '1.8.0');
+            const this_is_macos = osPlat == 'darwin';
+            if (this_is_macos && one_fileext_is_targz_and_other_is_dmg && this_julia_version_does_NOT_have_native_binaries_for_apple_silicon) {
+                const msg = `It looks like you are trying to install Julia 1.6 or 1.7 on ` +
+                    `the "macos-latest" runners.\n` +
+                    `"macos-latest" now resolves to "macos-14", which run on Apple ` +
+                    `Silicon (aarch64) macOS machines.\n` +
+                    `Unfortunately, Julia 1.6 and 1.7 do not have native binaries ` +
+                    `available for Apple Silicon macOS.\n` +
+                    `Therefore, it is not possible to install Julia with the current ` +
+                    `constraints.\n` +
+                    `You have three options:\n` +
+                    `Option 1: Switch from "macos-latest" to "macos-13" (because ` +
+                    `"macos-13" runs on Intel (x86_64) macOS machines.)\n` +
+                    `Option 2: Modify your CI matrix to exclude Julia 1.6 and 1.7 ` +
+                    `on "macos-latest", but continue to run Julia 1.6 or 1.7 on ` +
+                    `"macos-13".\n` +
+                    `Option 2: Explicitly request an x86_64 build of Julia, which ` +
+                    `macOS will run under emulation with Rosetta 2. To choose this ` +
+                    `option, explicitly pass "x64" as the value of the "arch" input ` +
+                    `to this action.\n` +
+                    `For more information, see this Discourse post: ` +
+                    `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019\n`;
+                core.error(msg);
+            }
+        }
     }
+    core.error(`Encountered error: ${err}`);
     throw err;
 }
 exports.getFileInfo = getFileInfo;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -184,6 +184,7 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
     }
 
     if (!versionInfo[version]) {
+       core.error(`Encountered error: ${err}`)
        throw err
     }
 
@@ -204,8 +205,49 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
                 }
             }
         }
+
+        // The following block is just to provide improved log messages in the CI logs.
+        // We specifically want to improve the case where someone is trying to install
+        // Julia 1.6 or 1.7 on Apple Silicon (aarch64) macOS.
+        {
+            const one_fileext_is_targz = (fileExt1 == "tar.gz") || (fileExt2 == "tar.gz");
+            const one_fileext_is_dmg = (fileExt1 == "dmg") || (fileExt2 == "dmg");
+            const one_fileext_is_targz_and_other_is_dmg = one_fileext_is_targz && one_fileext_is_dmg;
+
+            // We say that "this Julia version does NOT have native binaries for Apple Silicon"
+            // if and only if "this Julia version is < 1.8.0"
+            const this_julia_version_does_NOT_have_native_binaries_for_apple_silicon = semver.lt(
+                version,
+                '1.8.0',
+            );
+            const this_is_macos = osPlat == 'darwin';
+            if (this_is_macos && one_fileext_is_targz_and_other_is_dmg && this_julia_version_does_NOT_have_native_binaries_for_apple_silicon) {
+                const msg = `It looks like you are trying to install Julia 1.6 or 1.7 on ` +
+                            `the "macos-latest" runners.\n` +
+                            `"macos-latest" now resolves to "macos-14", which run on Apple ` +
+                            `Silicon (aarch64) macOS machines.\n` +
+                            `Unfortunately, Julia 1.6 and 1.7 do not have native binaries ` +
+                            `available for Apple Silicon macOS.\n` +
+                            `Therefore, it is not possible to install Julia with the current ` +
+                            `constraints.\n` +
+                            `You have three options:\n` +
+                            `Option 1: Switch from "macos-latest" to "macos-13" (because ` +
+                            `"macos-13" runs on Intel (x86_64) macOS machines.)\n` +
+                            `Option 2: Modify your CI matrix to exclude Julia 1.6 and 1.7 ` +
+                            `on "macos-latest", but continue to run Julia 1.6 or 1.7 on ` +
+                            `"macos-13".\n` +
+                            `Option 2: Explicitly request an x86_64 build of Julia, which ` +
+                            `macOS will run under emulation with Rosetta 2. To choose this ` +
+                            `option, explicitly pass "x64" as the value of the "arch" input ` +
+                            `to this action.\n` +
+                            `For more information, see this Discourse post: ` +
+                            `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019\n`
+                core.error(msg);
+            }
+        }
     }
 
+    core.error(`Encountered error: ${err}`)
     throw err
 }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -231,7 +231,7 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
                             `Therefore, it is not possible to install Julia with the current ` +
                             `constraints.\n` +
                             `For instructions on how to fix this error, please see the following Discourse post: ` +
-                            `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019\n`
+                            `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019`
                 core.error(msg);
             }
         }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -230,17 +230,7 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
                             `available for Apple Silicon macOS.\n` +
                             `Therefore, it is not possible to install Julia with the current ` +
                             `constraints.\n` +
-                            `You have three options:\n` +
-                            `Option 1: Switch from "macos-latest" to "macos-13" (because ` +
-                            `"macos-13" runs on Intel (x86_64) macOS machines.)\n` +
-                            `Option 2: Modify your CI matrix to exclude Julia 1.6 and 1.7 ` +
-                            `on "macos-latest", but continue to run Julia 1.6 or 1.7 on ` +
-                            `"macos-13".\n` +
-                            `Option 2: Explicitly request an x86_64 build of Julia, which ` +
-                            `macOS will run under emulation with Rosetta 2. To choose this ` +
-                            `option, explicitly pass "x64" as the value of the "arch" input ` +
-                            `to this action.\n` +
-                            `For more information, see this Discourse post: ` +
+                            `For instructions on how to fix this error, please see the following Discourse post: ` +
                             `https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019\n`
                 core.error(msg);
             }


### PR DESCRIPTION
Fixes #240 
Fixes #241 

At the end of the log message, we link to this Discourse post: https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019