### PR TITLE
Always print an error message, never error silently

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -214,6 +214,7 @@ function getFileInfo(versionInfo, version, arch) {
         return null;
     }
     if (!versionInfo[version]) {
+        core.error(`Encountered error: ${err}`);
         throw err;
     }
     for (let file of versionInfo[version].files) {
@@ -233,6 +234,7 @@ function getFileInfo(versionInfo, version, arch) {
             }
         }
     }
+    core.error(`Encountered error: ${err}`);
     throw err;
 }
 exports.getFileInfo = getFileInfo;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -184,6 +184,7 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
     }
 
     if (!versionInfo[version]) {
+       core.error(`Encountered error: ${err}`)
        throw err
     }
 
@@ -206,6 +207,7 @@ export function getFileInfo(versionInfo, version: string, arch: string) {
         }
     }
 
+    core.error(`Encountered error: ${err}`)
     throw err
 }
 


### PR DESCRIPTION
Ref #240 
Ref #241

This PR does NOT fix the actual problem in #240 or #241, but it does fix the problem of `setup-julia` erroring silently and not printing a log message.

With this PR, as a general rule, we always print the error message before we throw the error.