### PR TITLE
Improve example version instructions. Add info about "lts" if user specifies 1.6 explicitly

### DIFF
--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0.5', '1.2', '^1.5.0-beta1', '1', 'lts', 'pre']
+       # include '1.6' here to test info message about lts tag existing
+        julia-version: ['1.0.5', '1.2', '^1.5.0-beta1', '1', '1.6', 'lts', 'pre']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # 32-bit Julia binaries are not available on macOS

--- a/README.md
+++ b/README.md
@@ -5,17 +5,25 @@
 This action sets up a Julia environment for use in actions by downloading a specified version of Julia and adding it to PATH.
 
 ## Table of Contents
-- [Table of Contents](#table-of-contents)
-- [Usage](#usage)
-  - [Inputs](#inputs)
-  - [Outputs](#outputs)
-  - [Basic](#basic)
-  - [Julia Versions](#julia-versions)
-  - [Matrix Testing](#matrix-testing)
-  - [versioninfo](#versioninfo)
-- [Versioning](#versioning)
-- [Debug logs](#debug-logs)
-- [Third party information](#third-party-information)
+- [setup-julia Action](#setup-julia-action)
+  - [Table of Contents](#table-of-contents)
+  - [Usage](#usage)
+    - [Inputs](#inputs)
+    - [Outputs](#outputs)
+    - [Basic](#basic)
+    - [Julia Versions](#julia-versions)
+      - [Examples](#examples)
+      - [Prereleases](#prereleases)
+      - [Recently released versions](#recently-released-versions)
+    - [Matrix Testing](#matrix-testing)
+      - [64-bit Julia only](#64-bit-julia-only)
+      - [32-bit Julia](#32-bit-julia)
+    - [versioninfo](#versioninfo)
+  - [Versioning](#versioning)
+  - [Using Dependabot version updates to keep your GitHub Actions up to date](#using-dependabot-version-updates-to-keep-your-github-actions-up-to-date)
+  - [Debug logs](#debug-logs)
+  - [Third party information](#third-party-information)
+  - [Contributing to this repo](#contributing-to-this-repo)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This action sets up a Julia environment for use in actions by downloading a spec
     # Warning: It is strongly recommended to wrap this value in quotes.
     #          Otherwise, the YAML parser used by GitHub Actions parses certain
     #          versions as numbers which causes the wrong version to be selected.
-    #          For example, `1.0` may be parsed as `1`.
+    #          For example, `1.10` may be parsed as `1.1`.
     #
     # Default: '1'
     version: ''

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Setup a Julia environment and add it to the PATH'
 author: 'Sascha Mann'
 inputs:
   version:
-    description: 'The Julia version to download (if necessary) and use. Use a string input to avoid unwanted decimal conversion e.g. 1.10 will be interpreted as 1.1. Examples: "1", "1.10", "lts", "pre"'
+    description: 'The Julia version to download (if necessary) and use. Use a string input to avoid unwanted decimal conversion e.g. 1.10 without quotes will be interpreted as 1.1. Examples: "1", "1.10", "lts", "pre"'
     default: '1'
   include-all-prereleases:
     description: 'Include prereleases when matching the Julia version to available versions.'

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Setup Julia environment'
 description: 'Setup a Julia environment and add it to the PATH'
 author: 'Sascha Mann'
-inputs: 
+inputs:
   version:
-    description: 'The Julia version to download (if necessary) and use. Example: 1.0.4'
-    default: '1'
+    description: 'The Julia version to download (if necessary) and use. Use a string input to avoid unwanted decimal conversion e.g. 1.10 will be interpreted as 1.1. Examples: "1", "1.10", "lts", "pre"'
+    default: '"1"'
   include-all-prereleases:
     description: 'Include prereleases when matching the Julia version to available versions.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Sascha Mann'
 inputs:
   version:
     description: 'The Julia version to download (if necessary) and use. Use a string input to avoid unwanted decimal conversion e.g. 1.10 will be interpreted as 1.1. Examples: "1", "1.10", "lts", "pre"'
-    default: '"1"'
+    default: '1'
   include-all-prereleases:
     description: 'Include prereleases when matching the Julia version to available versions.'
     required: false

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -78,7 +78,7 @@ function run() {
                 throw new Error('Version input must not be null');
             }
             if (versionInput == '1.6') {
-                core.info('If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier, which will automatically resolve the current lts.');
+                core.info('::notice title=[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.');
             }
             if (!originalArchInput) {
                 throw new Error(`Arch input must not be null`);

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -78,7 +78,7 @@ function run() {
                 throw new Error('Version input must not be null');
             }
             if (versionInput == '1.6') {
-                core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.');
+                core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version, consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.');
             }
             if (!originalArchInput) {
                 throw new Error(`Arch input must not be null`);

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -77,6 +77,9 @@ function run() {
             if (!versionInput) {
                 throw new Error('Version input must not be null');
             }
+            if (versionInput == '1.6') {
+                core.info('If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier, which will automatically resolve the current lts.');
+            }
             if (!originalArchInput) {
                 throw new Error(`Arch input must not be null`);
             }

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -78,7 +78,7 @@ function run() {
                 throw new Error('Version input must not be null');
             }
             if (versionInput == '1.6') {
-                core.info('::notice title=[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.');
+                core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.');
             }
             if (!originalArchInput) {
                 throw new Error(`Arch input must not be null`);

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -51,7 +51,7 @@ async function run() {
             throw new Error('Version input must not be null')
         }
         if (versionInput == '1.6') {
-            core.info('::notice title=[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.')
+            core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.')
         }
         if (!originalArchInput) {
             throw new Error(`Arch input must not be null`)

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -50,6 +50,9 @@ async function run() {
         if (!versionInput) {
             throw new Error('Version input must not be null')
         }
+        if (versionInput == '1.6') {
+            core.info('If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier, which will automatically resolve the current lts.')
+        }
         if (!originalArchInput) {
             throw new Error(`Arch input must not be null`)
         }

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -51,7 +51,7 @@ async function run() {
             throw new Error('Version input must not be null')
         }
         if (versionInput == '1.6') {
-            core.info('If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier, which will automatically resolve the current lts.')
+            core.info('::notice title=[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.')
         }
         if (!originalArchInput) {
             throw new Error(`Arch input must not be null`)

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -51,7 +51,7 @@ async function run() {
             throw new Error('Version input must not be null')
         }
         if (versionInput == '1.6') {
-            core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.')
+            core.notice('[setup-julia] If you are testing 1.6 as a Long Term Support (lts) version, consider using the new "lts" version specifier instead of "1.6" explicitly, which will automatically resolve the current lts.')
         }
         if (!originalArchInput) {
             throw new Error(`Arch input must not be null`)


### PR DESCRIPTION
- I haven't found a way to catch https://github.com/julia-actions/setup-julia/issues/204 so explain the issue in the instructions 
- In preparation for 1.10 becoming LTS promote users to use "lts" rather than specify "1.6" explicitly.

i.e.
![Screenshot 2024-07-19 at 10 43 11 AM](https://github.com/user-attachments/assets/6beedee4-b219-4c83-8674-fe3a59a8fc24)
