### PR TITLE
Breaking: Change `min` to return the latest patch (but still the minimum major/minor); also, add `min-minor` and `min-patch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ You can either specify specific Julia versions or version ranges. If you specify
 - `'pre'` will install the latest prerelease build (RCs, betas, and alphas).
 - `'nightly'` will install the latest nightly build.
 - `'1.7-nightly'` will install the latest nightly build for the upcoming 1.7 release. This version will only be available during certain phases of the Julia release cycle.
-- `'min'` will install the earliest supported version of Julia compatible with the project. Especially useful in monorepos.
+- `'min'` is equivalent to `min-minor`.
+- `'min-minor'` will install the earliest supported major/minor version of Julia compatible with the project. Especially useful in monorepos. Note: `min-minor` chooses the lowest major/minor, but gives the latest patch. For example, for a Julia `[compat]` entry of `julia = "1.10"`, `min-minor` would resolve to e.g. `1.10.11` (NOT `1.10.0`).
+- `'min-patch'` will install the earliest supported major/minor/patch version of Julia compatible with the project. For example, for a Julia `[compat]` entry of `julia = "1.10"`, `min-patch` would resolve to e.g. `1.10.0`.
 
 Internally the action uses node's semver package to resolve version ranges. Its [documentation](https://github.com/npm/node-semver#advanced-range-syntax) contains more details on the version range syntax. You can test what version will be selected for a given input in this JavaScript [REPL](https://repl.it/@SaschaMann/setup-julia-version-logic).
 

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -217,34 +217,90 @@ describe('version matching tests', () => {
     describe('node-semver behaviour', () => {
         describe('Windows installer change', () => {
             it('Correctly understands >1.4.0', () => {
-                expect(semver.gtr('1.4.0-rc1', '1.3', {includePrerelease: true})).toBeTruthy()
-                expect(semver.gtr('1.4.0-DEV', '1.3', {includePrerelease: true})).toBeTruthy()
-                expect(semver.gtr('1.3.1', '1.3', {includePrerelease: true})).toBeFalsy()
-                expect(semver.gtr('1.3.2-rc1', '1.3', {includePrerelease: true})).toBeFalsy()
+                expect(semver.gtr('1.4.0-rc1', '1.3', { includePrerelease: true })).toBeTruthy()
+                expect(semver.gtr('1.4.0-DEV', '1.3', { includePrerelease: true })).toBeTruthy()
+                expect(semver.gtr('1.3.1', '1.3', { includePrerelease: true })).toBeFalsy()
+                expect(semver.gtr('1.3.2-rc1', '1.3', { includePrerelease: true })).toBeFalsy()
             })
         })
     })
 
-    describe('julia compat versions', () => {
+    describe('julia compat versions: min', () => {
         it('Understands "min"', () => {
             let versions = ["1.6.7", "1.7.1-rc1", "1.7.1-rc2", "1.7.1", "1.7.2", "1.8.0"]
-            expect(installer.getJuliaVersion(versions, "min", false, "^1.7")).toEqual("1.7.1")
-            expect(installer.getJuliaVersion(versions, "min", true, "^1.7")).toEqual("1.7.1-rc1")
+            expect(installer.getJuliaVersion(versions, "min", false, "^1.7")).toEqual("1.7.2")
+            expect(installer.getJuliaVersion(versions, "min", true, "^1.7")).toEqual("1.7.2")
 
             versions = ["1.6.7", "1.7.3-rc1", "1.7.3-rc2", "1.8.0"]
             expect(installer.getJuliaVersion(versions, "min", false, "^1.7")).toEqual("1.8.0")
-            expect(installer.getJuliaVersion(versions, "min", true, "^1.7")).toEqual("1.7.3-rc1")
+            expect(installer.getJuliaVersion(versions, "min", true, "^1.7")).toEqual("1.7.3-rc2")
 
             expect(installer.getJuliaVersion(versions, "min", false, "~1.7 || ~1.8 || ~1.9")).toEqual("1.8.0")
-            expect(installer.getJuliaVersion(versions, "min", true, "~1.7 || ~1.8 || ~1.9")).toEqual("1.7.3-rc1")
+            expect(installer.getJuliaVersion(versions, "min", true, "~1.7 || ~1.8 || ~1.9")).toEqual("1.7.3-rc2")
             expect(installer.getJuliaVersion(versions, "min", false, "~1.8 || ~1.7 || ~1.9")).toEqual("1.8.0")
-            expect(installer.getJuliaVersion(versions, "min", true, "~1.8 || ~1.7 || ~1.9")).toEqual("1.7.3-rc1")
+            expect(installer.getJuliaVersion(versions, "min", true, "~1.8 || ~1.7 || ~1.9")).toEqual("1.7.3-rc2")
 
             expect(installer.getJuliaVersion(versions, "min", false, "1.7 - 1.9")).toEqual("1.8.0")
-            expect(installer.getJuliaVersion(versions, "min", true, "1.7 - 1.9")).toEqual("1.7.3-rc1")
+            expect(installer.getJuliaVersion(versions, "min", true, "1.7 - 1.9")).toEqual("1.7.3-rc2")
 
             expect(installer.getJuliaVersion(versions, "min", true, "< 1.9.0")).toEqual("1.6.7")
             expect(installer.getJuliaVersion(versions, "min", true, ">= 1.6.0")).toEqual("1.6.7")
+
+            // NPM's semver package treats "1.7" as "~1.7" instead of "^1.7" like Julia
+            expect(() => installer.getJuliaVersion(versions, "min", false, "1.7")).toThrow("Could not find a Julia version that matches")
+
+            expect(() => installer.getJuliaVersion(versions, "min", true, "")).toThrow("Julia project file does not specify a compat for Julia")
+        })
+    })
+
+    describe('julia compat versions: min-minor', () => {
+        it('Understands "min-minor"', () => {
+            let versions = ["1.6.7", "1.7.1-rc1", "1.7.1-rc2", "1.7.1", "1.7.2", "1.8.0"]
+            expect(installer.getJuliaVersion(versions, "min-minor", false, "^1.7")).toEqual("1.7.2")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "^1.7")).toEqual("1.7.2")
+
+            versions = ["1.6.7", "1.7.3-rc1", "1.7.3-rc2", "1.8.0"]
+            expect(installer.getJuliaVersion(versions, "min-minor", false, "^1.7")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "^1.7")).toEqual("1.7.3-rc2")
+
+            expect(installer.getJuliaVersion(versions, "min-minor", false, "~1.7 || ~1.8 || ~1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "~1.7 || ~1.8 || ~1.9")).toEqual("1.7.3-rc2")
+            expect(installer.getJuliaVersion(versions, "min-minor", false, "~1.8 || ~1.7 || ~1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "~1.8 || ~1.7 || ~1.9")).toEqual("1.7.3-rc2")
+
+            expect(installer.getJuliaVersion(versions, "min-minor", false, "1.7 - 1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "1.7 - 1.9")).toEqual("1.7.3-rc2")
+
+            expect(installer.getJuliaVersion(versions, "min-minor", true, "< 1.9.0")).toEqual("1.6.7")
+            expect(installer.getJuliaVersion(versions, "min-minor", true, ">= 1.6.0")).toEqual("1.6.7")
+
+            // NPM's semver package treats "1.7" as "~1.7" instead of "^1.7" like Julia
+            expect(() => installer.getJuliaVersion(versions, "min", false, "1.7")).toThrow("Could not find a Julia version that matches")
+
+            expect(() => installer.getJuliaVersion(versions, "min", true, "")).toThrow("Julia project file does not specify a compat for Julia")
+        })
+    })
+
+    describe('julia compat versions: min-patch', () => {
+        it('Understands "min-patch"', () => {
+            let versions = ["1.6.7", "1.7.1-rc1", "1.7.1-rc2", "1.7.1", "1.7.2", "1.8.0"]
+            expect(installer.getJuliaVersion(versions, "min-patch", false, "^1.7")).toEqual("1.7.1")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "^1.7")).toEqual("1.7.1-rc1")
+
+            versions = ["1.6.7", "1.7.3-rc1", "1.7.3-rc2", "1.8.0"]
+            expect(installer.getJuliaVersion(versions, "min-patch", false, "^1.7")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "^1.7")).toEqual("1.7.3-rc1")
+
+            expect(installer.getJuliaVersion(versions, "min-patch", false, "~1.7 || ~1.8 || ~1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "~1.7 || ~1.8 || ~1.9")).toEqual("1.7.3-rc1")
+            expect(installer.getJuliaVersion(versions, "min-patch", false, "~1.8 || ~1.7 || ~1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "~1.8 || ~1.7 || ~1.9")).toEqual("1.7.3-rc1")
+
+            expect(installer.getJuliaVersion(versions, "min-patch", false, "1.7 - 1.9")).toEqual("1.8.0")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "1.7 - 1.9")).toEqual("1.7.3-rc1")
+
+            expect(installer.getJuliaVersion(versions, "min-patch", true, "< 1.9.0")).toEqual("1.6.7")
+            expect(installer.getJuliaVersion(versions, "min-patch", true, ">= 1.6.0")).toEqual("1.6.7")
 
             // NPM's semver package treats "1.7" as "~1.7" instead of "^1.7" like Julia
             expect(() => installer.getJuliaVersion(versions, "min", false, "1.7")).toThrow("Could not find a Julia version that matches")

--- a/dist/index.js
+++ b/dist/index.js
@@ -215,12 +215,28 @@ function getJuliaVersion(availableReleases, versionInput, includePrerelease = fa
         // versionInput is a valid version or a nightly version, use it directly
         version = versionInput;
     }
-    else if (versionInput == "min") {
+    else if (versionInput == "min" || versionInput == "min-minor" || versionInput == "min-patch") {
         // Resolve "min" to the minimum supported Julia version compatible with the project file
         if (!juliaCompatRange) {
-            throw new Error('Unable to use version "min" when the Julia project file does not specify a compat for Julia');
+            throw new Error('Unable to use version "min" (or "min-minor" or "min-patch") when the Julia project file does not specify a compat for Julia');
         }
-        version = semver.minSatisfying(availableReleases, juliaCompatRange, { includePrerelease });
+        // true_min_version is the actual minimum
+        // E.g. if the Julia [compat] entry is "1.10", then true_min_version is v"1.10.0"
+        let true_min_version = semver.minSatisfying(availableReleases, juliaCompatRange, { includePrerelease });
+        let my_tilde_range = `~${true_min_version}`;
+        // min_with_latest_patch is the minimum major/minor, but latest patch
+        // E.g. if the Julia [compat] entry is "1.10", then true__version is v"1.10.11" (or whatever the latest 1.10.x patch is)
+        // https://github.com/julia-actions/setup-julia/issues/372
+        let min_with_latest_patch = semver.maxSatisfying(availableReleases, my_tilde_range, { includePrerelease });
+        if (versionInput == "min" || versionInput == "min-minor") {
+            version = min_with_latest_patch;
+        }
+        else if (versionInput == "min-patch") {
+            version = true_min_version;
+        }
+        else {
+            throw new Error(`Unexpected error. Invalid value for versionInput: ${versionInput}`);
+        }
     }
     else if (versionInput == "lts") {
         version = semver.maxSatisfying(availableReleases, LTS_VERSION, { includePrerelease: false });

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -208,12 +208,28 @@ function getJuliaVersion(availableReleases, versionInput, includePrerelease = fa
         // versionInput is a valid version or a nightly version, use it directly
         version = versionInput;
     }
-    else if (versionInput == "min") {
+    else if (versionInput == "min" || versionInput == "min-minor" || versionInput == "min-patch") {
         // Resolve "min" to the minimum supported Julia version compatible with the project file
         if (!juliaCompatRange) {
-            throw new Error('Unable to use version "min" when the Julia project file does not specify a compat for Julia');
+            throw new Error('Unable to use version "min" (or "min-minor" or "min-patch") when the Julia project file does not specify a compat for Julia');
         }
-        version = semver.minSatisfying(availableReleases, juliaCompatRange, { includePrerelease });
+        // true_min_version is the actual minimum
+        // E.g. if the Julia [compat] entry is "1.10", then true_min_version is v"1.10.0"
+        let true_min_version = semver.minSatisfying(availableReleases, juliaCompatRange, { includePrerelease });
+        let my_tilde_range = `~${true_min_version}`;
+        // min_with_latest_patch is the minimum major/minor, but latest patch
+        // E.g. if the Julia [compat] entry is "1.10", then true__version is v"1.10.11" (or whatever the latest 1.10.x patch is)
+        // https://github.com/julia-actions/setup-julia/issues/372
+        let min_with_latest_patch = semver.maxSatisfying(availableReleases, my_tilde_range, { includePrerelease });
+        if (versionInput == "min" || versionInput == "min-minor") {
+            version = min_with_latest_patch;
+        }
+        else if (versionInput == "min-patch") {
+            version = true_min_version;
+        }
+        else {
+            throw new Error(`Unexpected error. Invalid value for versionInput: ${versionInput}`);
+        }
     }
     else if (versionInput == "lts") {
         version = semver.maxSatisfying(availableReleases, LTS_VERSION, { includePrerelease: false });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -174,12 +174,26 @@ export function getJuliaVersion(availableReleases: string[], versionInput: strin
     if (semver.valid(versionInput) == versionInput || versionInput.endsWith('nightly')) {
         // versionInput is a valid version or a nightly version, use it directly
         version = versionInput
-    } else if (versionInput == "min") {
+    } else if (versionInput == "min" || versionInput == "min-minor" || versionInput == "min-patch") {
         // Resolve "min" to the minimum supported Julia version compatible with the project file
         if (!juliaCompatRange) {
-            throw new Error('Unable to use version "min" when the Julia project file does not specify a compat for Julia')
+            throw new Error('Unable to use version "min" (or "min-minor" or "min-patch") when the Julia project file does not specify a compat for Julia')
         }
-        version = semver.minSatisfying(availableReleases, juliaCompatRange, {includePrerelease})
+        // true_min_version is the actual minimum
+        // E.g. if the Julia [compat] entry is "1.10", then true_min_version is v"1.10.0"
+        let true_min_version = semver.minSatisfying(availableReleases, juliaCompatRange, {includePrerelease})
+        let my_tilde_range = `~${true_min_version}`
+        // min_with_latest_patch is the minimum major/minor, but latest patch
+        // E.g. if the Julia [compat] entry is "1.10", then true__version is v"1.10.11" (or whatever the latest 1.10.x patch is)
+        // https://github.com/julia-actions/setup-julia/issues/372
+        let min_with_latest_patch = semver.maxSatisfying(availableReleases, my_tilde_range, {includePrerelease})
+        if (versionInput == "min" || versionInput == "min-minor") {
+            version = min_with_latest_patch
+        } else if (versionInput == "min-patch") {
+            version = true_min_version
+        } else {
+            throw new Error(`Unexpected error. Invalid value for versionInput: ${versionInput}`)
+        }
     } else if (versionInput == "lts") {
         version = semver.maxSatisfying(availableReleases, LTS_VERSION, { includePrerelease: false });
     } else if (versionInput == "pre") {


### PR DESCRIPTION
The major/minor will be the minimum, but the patch will be the latest. E.g. `julia = "1.10"` would lead to e.g. 1.10.11 (not 1.10.0).

Fixes #372

Before this PR:
- `min` => 1.10.0

After this PR:
- `min-patch` => 1.10.0 (minimum major/minor/patch)
- `min-minor` => 1.10.11 (minimum major/minor, latest patch)
- `min` => equivalent to `min-minor` (1.10.11)