### PR TITLE
README: Add a link to the v2-to-v3 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This action sets up a Julia environment for use in actions by downloading a specified version of Julia and adding it to PATH.
 
+[Migration guide for upgrading from v2 to v3](https://github.com/julia-actions/setup-julia/releases/tag/v3.0.0).
+
 ## Table of Contents
 - [setup-julia Action](#setup-julia-action)
   - [Table of Contents](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This action sets up a Julia environment for use in actions by downloading a specified version of Julia and adding it to PATH.
 
-[Migration guide for upgrading from v2 to v3](https://github.com/julia-actions/setup-julia/releases/tag/v3.0.0).
+[Release notes for v2 to v3](https://github.com/julia-actions/setup-julia/releases/tag/v3.0.0).
 
 ## Table of Contents
 - [setup-julia Action](#setup-julia-action)


### PR DESCRIPTION
The release notes (where this info currently lives) are indeed the best place to have this info, because Dependabot will pull the info directly from there.

However, some users may come directly to the README, in which case it may be helpful to have a link in the README.