### PR TITLE
Bug fix: Validate cached julia binary exists and check PATH resolution

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -561,6 +561,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(7484));
+const io = __importStar(__nccwpck_require__(4994));
 const tc = __importStar(__nccwpck_require__(3472));
 const fs = __importStar(__nccwpck_require__(9896));
 const https = __importStar(__nccwpck_require__(5692));
@@ -653,6 +654,17 @@ function run() {
             // Search in cache
             let juliaPath;
             juliaPath = tc.find('julia', version, arch);
+            // tc.find only checks for the .complete marker; the marker can be present
+            // while the directory is empty/partial because tc.cacheDir is called with
+            // an empty dir BEFORE installJulia extracts into it (see PR196 hack below).
+            // Validate the cached entry by checking the binary file exists.
+            if (juliaPath) {
+                const cachedJuliaBin = path.join(juliaPath, 'bin', os.platform() == 'win32' ? 'julia.exe' : 'julia');
+                if (!fs.existsSync(cachedJuliaBin)) {
+                    core.warning(`Cached Julia ${arch}/${version} at ${juliaPath} is incomplete (missing ${cachedJuliaBin}); reinstalling.`);
+                    juliaPath = '';
+                }
+            }
             if (!juliaPath) {
                 core.debug(`could not find Julia ${arch}/${version} in cache`);
                 // https://github.com/julia-actions/setup-julia/pull/196
@@ -672,9 +684,22 @@ function run() {
                 core.debug(`using cached version of Julia: ${juliaPath}`);
             }
             // Add it to PATH
-            core.addPath(path.join(juliaPath, 'bin'));
+            const juliaBindir = path.join(juliaPath, 'bin');
+            core.addPath(juliaBindir);
+            // Verify that PATH lookup of `julia` resolves to the binary we just installed.
+            // On self-hosted runners other Julia entries (e.g. juliaup launcher in
+            // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
+            const resolvedJulia = yield io.which('julia', true);
+            const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
+            const norm = (p) => {
+                const resolved = path.resolve(fs.realpathSync(p));
+                return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
+            };
+            if (norm(resolvedJulia) !== norm(expectedJulia)) {
+                core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`);
+            }
             // Set output
-            core.setOutput('julia-bindir', path.join(juliaPath, 'bin'));
+            core.setOutput('julia-bindir', juliaBindir);
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
             yield installer.showVersionInfo(showVersionInfoInput, version);

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -43,6 +43,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
+const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
 const https = __importStar(require("https"));
@@ -135,6 +136,17 @@ function run() {
             // Search in cache
             let juliaPath;
             juliaPath = tc.find('julia', version, arch);
+            // tc.find only checks for the .complete marker; the marker can be present
+            // while the directory is empty/partial because tc.cacheDir is called with
+            // an empty dir BEFORE installJulia extracts into it (see PR196 hack below).
+            // Validate the cached entry by checking the binary file exists.
+            if (juliaPath) {
+                const cachedJuliaBin = path.join(juliaPath, 'bin', os.platform() == 'win32' ? 'julia.exe' : 'julia');
+                if (!fs.existsSync(cachedJuliaBin)) {
+                    core.warning(`Cached Julia ${arch}/${version} at ${juliaPath} is incomplete (missing ${cachedJuliaBin}); reinstalling.`);
+                    juliaPath = '';
+                }
+            }
             if (!juliaPath) {
                 core.debug(`could not find Julia ${arch}/${version} in cache`);
                 // https://github.com/julia-actions/setup-julia/pull/196
@@ -154,9 +166,22 @@ function run() {
                 core.debug(`using cached version of Julia: ${juliaPath}`);
             }
             // Add it to PATH
-            core.addPath(path.join(juliaPath, 'bin'));
+            const juliaBindir = path.join(juliaPath, 'bin');
+            core.addPath(juliaBindir);
+            // Verify that PATH lookup of `julia` resolves to the binary we just installed.
+            // On self-hosted runners other Julia entries (e.g. juliaup launcher in
+            // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
+            const resolvedJulia = yield io.which('julia', true);
+            const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
+            const norm = (p) => {
+                const resolved = path.resolve(fs.realpathSync(p));
+                return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
+            };
+            if (norm(resolvedJulia) !== norm(expectedJulia)) {
+                core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`);
+            }
             // Set output
-            core.setOutput('julia-bindir', path.join(juliaPath, 'bin'));
+            core.setOutput('julia-bindir', juliaBindir);
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
             yield installer.showVersionInfo(showVersionInfoInput, version);

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import * as io from '@actions/io'
 import * as tc from '@actions/tool-cache'
 
 import * as fs from 'fs'
@@ -102,6 +103,18 @@ async function run() {
         let juliaPath: string;
         juliaPath = tc.find('julia', version, arch)
 
+        // tc.find only checks for the .complete marker; the marker can be present
+        // while the directory is empty/partial because tc.cacheDir is called with
+        // an empty dir BEFORE installJulia extracts into it (see PR196 hack below).
+        // Validate the cached entry by checking the binary file exists.
+        if (juliaPath) {
+            const cachedJuliaBin = path.join(juliaPath, 'bin', os.platform() == 'win32' ? 'julia.exe' : 'julia')
+            if (!fs.existsSync(cachedJuliaBin)) {
+                core.warning(`Cached Julia ${arch}/${version} at ${juliaPath} is incomplete (missing ${cachedJuliaBin}); reinstalling.`)
+                juliaPath = ''
+            }
+        }
+
         if (!juliaPath) {
             core.debug(`could not find Julia ${arch}/${version} in cache`)
 
@@ -124,10 +137,24 @@ async function run() {
         }
 
         // Add it to PATH
-        core.addPath(path.join(juliaPath, 'bin'))
+        const juliaBindir = path.join(juliaPath, 'bin')
+        core.addPath(juliaBindir)
+
+        // Verify that PATH lookup of `julia` resolves to the binary we just installed.
+        // On self-hosted runners other Julia entries (e.g. juliaup launcher in
+        // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
+        const resolvedJulia = await io.which('julia', true)
+        const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia')
+        const norm = (p: string) => {
+            const resolved = path.resolve(fs.realpathSync(p))
+            return os.platform() == 'win32' ? resolved.toLowerCase() : resolved
+        }
+        if (norm(resolvedJulia) !== norm(expectedJulia)) {
+            core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`)
+        }
 
         // Set output
-        core.setOutput('julia-bindir', path.join(juliaPath, 'bin'))
+        core.setOutput('julia-bindir', juliaBindir)
 
         // Test if Julia has been installed and print the version
         const showVersionInfoInput = core.getInput('show-versioninfo')


### PR DESCRIPTION
I noticed this in CI. It's related to some problems with juliaup being installed on the workers and being messed with by install-juliaup (but that's a different issue)

```
/home/actions-runner-12/.juliaup/bin/julia --version
Error: The Julia launcher failed to figure out which juliaup channel to use.
Error: The process '/home/actions-runner-12/.juliaup/bin/julia' failed with exit code 1
```

setup-julia failed here at the `julia --version` check, because path resolved to a faulty local juliaup installation. This makes me think the cached binary might not have been fully there (just a .complete marker present).

# Changes

### 1. Added `bin/julia` exists check which causes a cache miss on failure prompting a new download
   
  | `.complete` | `bin/julia` exists | Before | After |                                                                                                                                  
  |---|---|---|---|                                                
  | absent | — | miss | miss |                                                                                                                                                           
  | present | absent | **hit** | **miss** |
  | present | present | hit | hit |                                                                                                                                                      
                                                                   
### 2. Added a PATH resolution check (warning)

We're basically checking if the selected Julia version/binary is the one that would resolve from PATH. I'm not sure if this should be fatal, so leaving it as a warning in case such an issue appears again.
   


