### PR TITLE
CI: Update all external GitHub Actions, and pin them to full-length commit hashes

### DIFF
--- a/.github/workflows/MakeFromScratch.yml
+++ b/.github/workflows/MakeFromScratch.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/example-builds-defaultarch.yml
+++ b/.github/workflows/example-builds-defaultarch.yml
@@ -23,9 +23,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ ! startsWith(github.ref, 'refs/heads/releases') }}
         with:
           node-version-file: '.tool-versions'

--- a/.github/workflows/example-builds-nightly-defaultarch.yml
+++ b/.github/workflows/example-builds-nightly-defaultarch.yml
@@ -27,9 +27,9 @@ jobs:
           - macos-latest # Apple Silicon
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ ! startsWith(github.ref, 'refs/heads/releases') }}
         with:
           node-version-file: '.tool-versions'

--- a/.github/workflows/example-builds-nightly.yml
+++ b/.github/workflows/example-builds-nightly.yml
@@ -39,9 +39,9 @@ jobs:
             julia-wordsize: 32
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ ! startsWith(github.ref, 'refs/heads/releases') }}
         with:
           node-version-file: '.tool-versions'

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -53,11 +53,11 @@ jobs:
           - os: macos-latest # Apple Silicon
             julia-version: '1.6'
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ ! startsWith(github.ref, 'refs/heads/releases') }}
         with:
           node-version-file: '.tool-versions'
@@ -100,11 +100,11 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
 

--- a/.github/workflows/example-builds.yml
+++ b/.github/workflows/example-builds.yml
@@ -100,7 +100,7 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -53,7 +53,7 @@ jobs:
       # Windows:
         # Windows does not support asdf, so we have to use `actions/setup-node`
         # to install asdf:
-      - uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: runner.os == 'Windows'
         with:
           node-version-file: '.tool-versions'
@@ -96,7 +96,7 @@ jobs:
       # Windows:
         # Windows does not support asdf, so we have to use `actions/setup-node`
         # to install asdf:
-      - uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: runner.os == 'Windows'
         with:
           node-version-file: '.tool-versions'
@@ -140,7 +140,7 @@ jobs:
       # Windows:
         # Windows does not support asdf, so we have to use `actions/setup-node`
         # to install asdf:
-      - uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: runner.os == 'Windows'
         with:
           node-version-file: '.tool-versions'


### PR DESCRIPTION
TODO after merging:
- [x] After this PR has been merged, I will enable the "Require actions to be pinned to a full-length commit SHA" requirement in the repo settings. 