### PR TITLE
Dethrone preinstalled Julia that shadows setup-julia's install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ outputs:
   julia-bindir: ''
 ```
 
+### Environment variables
+
+The action exports the following environment variables for use by subsequent
+steps and downstream actions:
+
+- `JULIA_ACTIONS_JULIA`: the absolute path to the Julia executable that this
+  action installed (e.g. `/opt/hostedtoolcache/julia/1.5.3/x64/bin/julia`).
+  Downstream actions can invoke this directly instead of relying on a bare
+  `julia` PATH lookup, which can be shadowed by a Julia preinstalled on the
+  runner image. Prefer it when set, falling back to `julia`, e.g.
+  `"${JULIA_ACTIONS_JULIA:-julia}"`.
+
 ### Basic
 
 ```yaml

--- a/__tests__/path.test.ts
+++ b/__tests__/path.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import * as core from '@actions/core'
+import * as io from '@actions/io'
+
+jest.mock('@actions/core')
+jest.mock('@actions/io')
+
+import {configureJuliaPath} from '../src/path'
+
+const exeName = os.platform() == 'win32' ? 'julia.exe' : 'julia'
+
+// Create a fake Julia install rooted at a fresh temp directory. When `withShare`
+// is true it also creates the `share/julia` directory that marks a self-contained
+// Julia install (as opposed to e.g. a shared shim directory).
+function makeJuliaInstall(withShare: boolean): {root: string; bindir: string; exe: string} {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-julia-test-'))
+    const bindir = path.join(root, 'bin')
+    fs.mkdirSync(bindir, {recursive: true})
+    const exe = path.join(bindir, exeName)
+    fs.writeFileSync(exe, '')
+    if (withShare) {
+        fs.mkdirSync(path.join(root, 'share', 'julia'), {recursive: true})
+    }
+    return {root, bindir, exe}
+}
+
+function exportedValue(name: string): string | undefined {
+    const call = (core.exportVariable as jest.Mock).mock.calls.find(c => c[0] === name)
+    return call ? (call[1] as string) : undefined
+}
+
+describe('configureJuliaPath', () => {
+    let createdRoots: string[]
+    let originalPath: string | undefined
+
+    beforeEach(() => {
+        createdRoots = []
+        originalPath = process.env['PATH']
+    })
+
+    afterEach(() => {
+        if (originalPath === undefined) {
+            delete process.env['PATH']
+        } else {
+            process.env['PATH'] = originalPath
+        }
+        for (const root of createdRoots) {
+            fs.rmSync(root, {recursive: true, force: true})
+        }
+    })
+
+    function install(withShare: boolean) {
+        const result = makeJuliaInstall(withShare)
+        createdRoots.push(result.root)
+        return result
+    }
+
+    it('adds the bindir to PATH and exports JULIA_ACTIONS_JULIA + julia-bindir when no other Julia is present', async () => {
+        const ours = install(true)
+        ;(io.which as jest.Mock).mockResolvedValue('')
+
+        await configureJuliaPath(ours.root)
+
+        expect(core.addPath).toHaveBeenCalledWith(ours.bindir)
+        expect(core.exportVariable).toHaveBeenCalledWith('JULIA_ACTIONS_JULIA', ours.exe)
+        expect(core.setOutput).toHaveBeenCalledWith('julia-bindir', ours.bindir)
+        // No shadowing Julia, so PATH is not rewritten and no warning is emitted.
+        expect(exportedValue('PATH')).toBeUndefined()
+        expect(core.warning).not.toHaveBeenCalled()
+    })
+
+    it('removes a shadowing dedicated Julia install from PATH for subsequent steps', async () => {
+        const ours = install(true)
+        const shadow = install(true) // dedicated install (has share/julia)
+        const other = install(false) // unrelated dir that must be preserved
+        process.env['PATH'] = [shadow.bindir, other.bindir].join(path.delimiter)
+        ;(io.which as jest.Mock).mockResolvedValue(shadow.exe)
+
+        await configureJuliaPath(ours.root)
+
+        expect(core.exportVariable).toHaveBeenCalledWith('JULIA_ACTIONS_JULIA', ours.exe)
+        const newPath = exportedValue('PATH')
+        expect(newPath).toBeDefined()
+        const entries = (newPath as string).split(path.delimiter)
+        expect(entries).not.toContain(shadow.bindir)
+        expect(entries).toContain(other.bindir)
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Removed'))
+    })
+
+    it('does not strip a shared (non-dedicated) directory from PATH, but still warns', async () => {
+        const ours = install(true)
+        const shadow = install(false) // looks like a shim dir: no share/julia
+        process.env['PATH'] = shadow.bindir
+        ;(io.which as jest.Mock).mockResolvedValue(shadow.exe)
+
+        await configureJuliaPath(ours.root)
+
+        expect(exportedValue('PATH')).toBeUndefined()
+        expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('does not look like a dedicated Julia install'))
+    })
+
+    it('does nothing extra when the only Julia on PATH is the one we installed', async () => {
+        const ours = install(true)
+        ;(io.which as jest.Mock).mockResolvedValue(ours.exe)
+
+        await configureJuliaPath(ours.root)
+
+        expect(core.exportVariable).toHaveBeenCalledWith('JULIA_ACTIONS_JULIA', ours.exe)
+        expect(exportedValue('PATH')).toBeUndefined()
+        expect(core.warning).not.toHaveBeenCalled()
+    })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -512,6 +512,125 @@ function showVersionInfo(showVersionInfoInput, version) {
 
 /***/ }),
 
+/***/ 8981:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.configureJuliaPath = configureJuliaPath;
+const core = __importStar(__nccwpck_require__(7484));
+const io = __importStar(__nccwpck_require__(4994));
+const fs = __importStar(__nccwpck_require__(9896));
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(6928));
+// Normalise a path for comparison: resolve symlinks, make it absolute, and (on
+// Windows, where the filesystem is case-insensitive) lower-case it. Throws if
+// the path does not exist.
+function normalizePath(p) {
+    const resolved = path.resolve(fs.realpathSync(p));
+    return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
+}
+// Configure PATH and the environment so that subsequent steps and downstream
+// actions use the Julia we just installed at `juliaPath`, dethroning any Julia
+// preinstalled on the runner image that would otherwise shadow it.
+function configureJuliaPath(juliaPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const juliaBindir = path.join(juliaPath, 'bin');
+        const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
+        // Detect any Julia already resolvable on PATH *before* we prepend ours. Some
+        // runner images (e.g. GitHub's `windows-2025`) ship a Julia on PATH that can
+        // shadow the version we install when a later step invokes bare `julia` (e.g.
+        // via Git Bash on Windows). Capture it now so we can dethrone it below.
+        const preexistingJulia = yield io.which('julia', false);
+        // Add our Julia to PATH for subsequent steps.
+        core.addPath(juliaBindir);
+        // Export the absolute path to the Julia we just installed so that downstream
+        // actions (e.g. julia-runtest) can invoke it directly and bypass PATH lookup
+        // entirely, which is immune to any shadowing.
+        core.exportVariable('JULIA_ACTIONS_JULIA', expectedJulia);
+        // Set output
+        core.setOutput('julia-bindir', juliaBindir);
+        // If a different Julia was already on PATH, prepending ours is not always
+        // enough: depending on PATH state it can still win bare `julia` lookups in
+        // later steps. Remove its bin directory from PATH for subsequent steps, but
+        // only when that directory is a self-contained Julia install, so we never drop
+        // a shared directory (e.g. a Chocolatey shim dir) that holds other tools too.
+        // The PATH change is scoped to this job and touches no files, so it is safe on
+        // self-hosted runners.
+        if (preexistingJulia && normalizePath(preexistingJulia) !== normalizePath(expectedJulia)) {
+            const shadowBindir = path.dirname(path.resolve(fs.realpathSync(preexistingJulia)));
+            const isDedicatedJuliaDir = fs.existsSync(path.join(shadowBindir, '..', 'share', 'julia'));
+            if (isDedicatedJuliaDir) {
+                const shadowNorm = normalizePath(shadowBindir);
+                const cleaned = (process.env['PATH'] || '')
+                    .split(path.delimiter)
+                    .filter(entry => {
+                    if (!entry)
+                        return false;
+                    try {
+                        return normalizePath(entry) !== shadowNorm;
+                    }
+                    catch (_a) {
+                        return true;
+                    }
+                })
+                    .join(path.delimiter);
+                core.exportVariable('PATH', cleaned);
+                core.warning(`A preinstalled Julia at ${preexistingJulia} was shadowing setup-julia's install at ${expectedJulia}. Removed ${shadowBindir} from PATH for subsequent steps. Downstream actions can also use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly.`);
+            }
+            else {
+                core.warning(`A preinstalled Julia at ${preexistingJulia} may shadow setup-julia's install at ${expectedJulia} when a later step invokes bare \`julia\`. Its directory was left on PATH because it does not look like a dedicated Julia install. Use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly, or fix the runner's PATH.`);
+            }
+        }
+    });
+}
+
+
+/***/ }),
+
 /***/ 5901:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -561,13 +680,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(7484));
-const io = __importStar(__nccwpck_require__(4994));
 const tc = __importStar(__nccwpck_require__(3472));
 const fs = __importStar(__nccwpck_require__(9896));
 const https = __importStar(__nccwpck_require__(5692));
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const installer = __importStar(__nccwpck_require__(8328));
+const path_1 = __nccwpck_require__(8981);
 // Note: before we index into this dict, we always first do `.toLowerCase()` on
 // the key.
 //
@@ -683,23 +802,10 @@ function run() {
             else {
                 core.debug(`using cached version of Julia: ${juliaPath}`);
             }
-            // Add it to PATH
-            const juliaBindir = path.join(juliaPath, 'bin');
-            core.addPath(juliaBindir);
-            // Verify that PATH lookup of `julia` resolves to the binary we just installed.
-            // On self-hosted runners other Julia entries (e.g. juliaup launcher in
-            // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
-            const resolvedJulia = yield io.which('julia', true);
-            const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
-            const norm = (p) => {
-                const resolved = path.resolve(fs.realpathSync(p));
-                return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
-            };
-            if (norm(resolvedJulia) !== norm(expectedJulia)) {
-                core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`);
-            }
-            // Set output
-            core.setOutput('julia-bindir', juliaBindir);
+            // Configure PATH and the environment so that subsequent steps and
+            // downstream actions use the Julia we just installed, dethroning any Julia
+            // preinstalled on the runner image that would otherwise shadow it.
+            yield (0, path_1.configureJuliaPath)(juliaPath);
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
             yield installer.showVersionInfo(showVersionInfoInput, version);

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,0 +1,111 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.configureJuliaPath = configureJuliaPath;
+const core = __importStar(require("@actions/core"));
+const io = __importStar(require("@actions/io"));
+const fs = __importStar(require("fs"));
+const os = __importStar(require("os"));
+const path = __importStar(require("path"));
+// Normalise a path for comparison: resolve symlinks, make it absolute, and (on
+// Windows, where the filesystem is case-insensitive) lower-case it. Throws if
+// the path does not exist.
+function normalizePath(p) {
+    const resolved = path.resolve(fs.realpathSync(p));
+    return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
+}
+// Configure PATH and the environment so that subsequent steps and downstream
+// actions use the Julia we just installed at `juliaPath`, dethroning any Julia
+// preinstalled on the runner image that would otherwise shadow it.
+function configureJuliaPath(juliaPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const juliaBindir = path.join(juliaPath, 'bin');
+        const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
+        // Detect any Julia already resolvable on PATH *before* we prepend ours. Some
+        // runner images (e.g. GitHub's `windows-2025`) ship a Julia on PATH that can
+        // shadow the version we install when a later step invokes bare `julia` (e.g.
+        // via Git Bash on Windows). Capture it now so we can dethrone it below.
+        const preexistingJulia = yield io.which('julia', false);
+        // Add our Julia to PATH for subsequent steps.
+        core.addPath(juliaBindir);
+        // Export the absolute path to the Julia we just installed so that downstream
+        // actions (e.g. julia-runtest) can invoke it directly and bypass PATH lookup
+        // entirely, which is immune to any shadowing.
+        core.exportVariable('JULIA_ACTIONS_JULIA', expectedJulia);
+        // Set output
+        core.setOutput('julia-bindir', juliaBindir);
+        // If a different Julia was already on PATH, prepending ours is not always
+        // enough: depending on PATH state it can still win bare `julia` lookups in
+        // later steps. Remove its bin directory from PATH for subsequent steps, but
+        // only when that directory is a self-contained Julia install, so we never drop
+        // a shared directory (e.g. a Chocolatey shim dir) that holds other tools too.
+        // The PATH change is scoped to this job and touches no files, so it is safe on
+        // self-hosted runners.
+        if (preexistingJulia && normalizePath(preexistingJulia) !== normalizePath(expectedJulia)) {
+            const shadowBindir = path.dirname(path.resolve(fs.realpathSync(preexistingJulia)));
+            const isDedicatedJuliaDir = fs.existsSync(path.join(shadowBindir, '..', 'share', 'julia'));
+            if (isDedicatedJuliaDir) {
+                const shadowNorm = normalizePath(shadowBindir);
+                const cleaned = (process.env['PATH'] || '')
+                    .split(path.delimiter)
+                    .filter(entry => {
+                    if (!entry)
+                        return false;
+                    try {
+                        return normalizePath(entry) !== shadowNorm;
+                    }
+                    catch (_a) {
+                        return true;
+                    }
+                })
+                    .join(path.delimiter);
+                core.exportVariable('PATH', cleaned);
+                core.warning(`A preinstalled Julia at ${preexistingJulia} was shadowing setup-julia's install at ${expectedJulia}. Removed ${shadowBindir} from PATH for subsequent steps. Downstream actions can also use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly.`);
+            }
+            else {
+                core.warning(`A preinstalled Julia at ${preexistingJulia} may shadow setup-julia's install at ${expectedJulia} when a later step invokes bare \`julia\`. Its directory was left on PATH because it does not look like a dedicated Julia install. Use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly, or fix the runner's PATH.`);
+            }
+        }
+    });
+}

--- a/lib/setup-julia.js
+++ b/lib/setup-julia.js
@@ -43,13 +43,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
-const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
 const https = __importStar(require("https"));
 const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 const installer = __importStar(require("./installer"));
+const path_1 = require("./path");
 // Note: before we index into this dict, we always first do `.toLowerCase()` on
 // the key.
 //
@@ -165,23 +165,10 @@ function run() {
             else {
                 core.debug(`using cached version of Julia: ${juliaPath}`);
             }
-            // Add it to PATH
-            const juliaBindir = path.join(juliaPath, 'bin');
-            core.addPath(juliaBindir);
-            // Verify that PATH lookup of `julia` resolves to the binary we just installed.
-            // On self-hosted runners other Julia entries (e.g. juliaup launcher in
-            // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
-            const resolvedJulia = yield io.which('julia', true);
-            const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia');
-            const norm = (p) => {
-                const resolved = path.resolve(fs.realpathSync(p));
-                return os.platform() == 'win32' ? resolved.toLowerCase() : resolved;
-            };
-            if (norm(resolvedJulia) !== norm(expectedJulia)) {
-                core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`);
-            }
-            // Set output
-            core.setOutput('julia-bindir', juliaBindir);
+            // Configure PATH and the environment so that subsequent steps and
+            // downstream actions use the Julia we just installed, dethroning any Julia
+            // preinstalled on the runner image that would otherwise shadow it.
+            yield (0, path_1.configureJuliaPath)(juliaPath);
             // Test if Julia has been installed and print the version
             const showVersionInfoInput = core.getInput('show-versioninfo');
             yield installer.showVersionInfo(showVersionInfoInput, version);

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,69 @@
+import * as core from '@actions/core'
+import * as io from '@actions/io'
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+// Normalise a path for comparison: resolve symlinks, make it absolute, and (on
+// Windows, where the filesystem is case-insensitive) lower-case it. Throws if
+// the path does not exist.
+function normalizePath(p: string): string {
+    const resolved = path.resolve(fs.realpathSync(p))
+    return os.platform() == 'win32' ? resolved.toLowerCase() : resolved
+}
+
+// Configure PATH and the environment so that subsequent steps and downstream
+// actions use the Julia we just installed at `juliaPath`, dethroning any Julia
+// preinstalled on the runner image that would otherwise shadow it.
+export async function configureJuliaPath(juliaPath: string): Promise<void> {
+    const juliaBindir = path.join(juliaPath, 'bin')
+    const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia')
+
+    // Detect any Julia already resolvable on PATH *before* we prepend ours. Some
+    // runner images (e.g. GitHub's `windows-2025`) ship a Julia on PATH that can
+    // shadow the version we install when a later step invokes bare `julia` (e.g.
+    // via Git Bash on Windows). Capture it now so we can dethrone it below.
+    const preexistingJulia = await io.which('julia', false)
+
+    // Add our Julia to PATH for subsequent steps.
+    core.addPath(juliaBindir)
+
+    // Export the absolute path to the Julia we just installed so that downstream
+    // actions (e.g. julia-runtest) can invoke it directly and bypass PATH lookup
+    // entirely, which is immune to any shadowing.
+    core.exportVariable('JULIA_ACTIONS_JULIA', expectedJulia)
+
+    // Set output
+    core.setOutput('julia-bindir', juliaBindir)
+
+    // If a different Julia was already on PATH, prepending ours is not always
+    // enough: depending on PATH state it can still win bare `julia` lookups in
+    // later steps. Remove its bin directory from PATH for subsequent steps, but
+    // only when that directory is a self-contained Julia install, so we never drop
+    // a shared directory (e.g. a Chocolatey shim dir) that holds other tools too.
+    // The PATH change is scoped to this job and touches no files, so it is safe on
+    // self-hosted runners.
+    if (preexistingJulia && normalizePath(preexistingJulia) !== normalizePath(expectedJulia)) {
+        const shadowBindir = path.dirname(path.resolve(fs.realpathSync(preexistingJulia)))
+        const isDedicatedJuliaDir = fs.existsSync(path.join(shadowBindir, '..', 'share', 'julia'))
+        if (isDedicatedJuliaDir) {
+            const shadowNorm = normalizePath(shadowBindir)
+            const cleaned = (process.env['PATH'] || '')
+                .split(path.delimiter)
+                .filter(entry => {
+                    if (!entry) return false
+                    try {
+                        return normalizePath(entry) !== shadowNorm
+                    } catch {
+                        return true
+                    }
+                })
+                .join(path.delimiter)
+            core.exportVariable('PATH', cleaned)
+            core.warning(`A preinstalled Julia at ${preexistingJulia} was shadowing setup-julia's install at ${expectedJulia}. Removed ${shadowBindir} from PATH for subsequent steps. Downstream actions can also use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly.`)
+        } else {
+            core.warning(`A preinstalled Julia at ${preexistingJulia} may shadow setup-julia's install at ${expectedJulia} when a later step invokes bare \`julia\`. Its directory was left on PATH because it does not look like a dedicated Julia install. Use the JULIA_ACTIONS_JULIA environment variable to invoke the installed Julia directly, or fix the runner's PATH.`)
+        }
+    }
+}

--- a/src/setup-julia.ts
+++ b/src/setup-julia.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import * as io from '@actions/io'
 import * as tc from '@actions/tool-cache'
 
 import * as fs from 'fs'
@@ -8,6 +7,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import * as installer from './installer'
+import {configureJuliaPath} from './path'
 
 // Note: before we index into this dict, we always first do `.toLowerCase()` on
 // the key.
@@ -136,25 +136,10 @@ async function run() {
             core.debug(`using cached version of Julia: ${juliaPath}`)
         }
 
-        // Add it to PATH
-        const juliaBindir = path.join(juliaPath, 'bin')
-        core.addPath(juliaBindir)
-
-        // Verify that PATH lookup of `julia` resolves to the binary we just installed.
-        // On self-hosted runners other Julia entries (e.g. juliaup launcher in
-        // ~/.juliaup/bin) can shadow the toolcache binary depending on PATH state.
-        const resolvedJulia = await io.which('julia', true)
-        const expectedJulia = path.join(juliaBindir, os.platform() == 'win32' ? 'julia.exe' : 'julia')
-        const norm = (p: string) => {
-            const resolved = path.resolve(fs.realpathSync(p))
-            return os.platform() == 'win32' ? resolved.toLowerCase() : resolved
-        }
-        if (norm(resolvedJulia) !== norm(expectedJulia)) {
-            core.warning(`PATH lookup of \`julia\` resolves to ${resolvedJulia}, not the installed binary at ${expectedJulia}. Another Julia in PATH is shadowing setup-julia's install; fix the runner's PATH (e.g. remove or reorder \`~/.juliaup/bin\`).`)
-        }
-
-        // Set output
-        core.setOutput('julia-bindir', juliaBindir)
+        // Configure PATH and the environment so that subsequent steps and
+        // downstream actions use the Julia we just installed, dethroning any Julia
+        // preinstalled on the runner image that would otherwise shadow it.
+        await configureJuliaPath(juliaPath)
 
         // Test if Julia has been installed and print the version
         const showVersionInfoInput = core.getInput('show-versioninfo')


### PR DESCRIPTION
On Pkg CI we've started seeing the preinstalled image julia be used by julia-runtests
https://github.com/JuliaLang/Pkg.jl/actions/runs/27909840469/job/82584941476?pr=4700#step:5:95

Not sure exactly why it suddenly started happening, but this PR tries to fix the issue and provide an env var for consumers to use directly if they want.

Relates to #89

Claude:

---


GitHub's `windows-2025` runner image ships Julia preinstalled on PATH
(at `c:\julia`), which wins bare `julia` lookups in later steps (e.g.
via Git Bash) and shadows the version setup-julia installs. Prepending
our bindir via `core.addPath` is not always enough.

- Extract the PATH/env setup into `src/path.ts` (`configureJuliaPath`)
  so it can be unit tested without running the full action.
- Export `JULIA_ACTIONS_JULIA` (absolute path to the installed Julia)
  so downstream actions can invoke it directly and bypass PATH lookup,
  which is immune to any shadowing.
- Detect a preexisting Julia on PATH and, when it is a self-contained
  install (has `share/julia`), remove its bin dir from PATH for
  subsequent steps. Never strip a shared dir (e.g. a Chocolatey shim
  dir). The PATH change is job-scoped and touches no files, so it is
  safe on self-hosted runners.
- Document `JULIA_ACTIONS_JULIA` in the README.
- Add tests for `configureJuliaPath`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>